### PR TITLE
Hotfix/ CORS 필터 설정

### DIFF
--- a/src/main/java/com/jjbacsa/jjbacsabackend/etc/config/BeanConfig.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/etc/config/BeanConfig.java
@@ -6,6 +6,13 @@ import org.springframework.context.annotation.Configuration;
 
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import java.util.Arrays;
 
 @Configuration
 public class BeanConfig {
@@ -16,5 +23,19 @@ public class BeanConfig {
     @Bean
     public JPAQueryFactory jpaQueryFactory(){
         return new JPAQueryFactory(entityManager);
+    }
+    @Bean
+    CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+
+        // TODO: front 웹 도메인으로 변경
+        configuration.setAllowedOriginPatterns(Arrays.asList("http://localhost:3000"));
+        configuration.setAllowedMethods(Arrays.asList("HEAD","POST","GET","DELETE","PUT"));
+        configuration.setAllowedHeaders(Arrays.asList("*"));
+        configuration.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
     }
 }

--- a/src/main/java/com/jjbacsa/jjbacsabackend/etc/config/SecurityConfig.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/etc/config/SecurityConfig.java
@@ -45,6 +45,7 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception{
         http.csrf().disable();
+        http.cors();
 
         // header에 id, pw가 아닌 token(jwt)을 달고 간다. 그래서 basic이 아닌 bearer를 사용한다.
         http.httpBasic().disable()


### PR DESCRIPTION
프런트에서 api 호출 시 발생하는 CORS 에러에 대한 필터 설정

추후 front 쪽 웹 도메인을 생성하면 allow-origin 수정할 것