### PR TITLE
Hotfix/invalid annotation 수정

### DIFF
--- a/src/main/java/com/jjbacsa/jjbacsabackend/shop/repository/ShopRepository.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/shop/repository/ShopRepository.java
@@ -1,7 +1,7 @@
 package com.jjbacsa.jjbacsabackend.shop.repository;
 
 import com.jjbacsa.jjbacsabackend.shop.entity.ShopEntity;
-import io.lettuce.core.dynamic.annotation.Param;
+import org.springframework.data.repository.query.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;


### PR DESCRIPTION
* Query어노테이션에서 Parameter를 불러올 때 Param 어노테이션을 사용해 명시해야하는데, 스프링프레임워크에서 제공해주는 Param 어노테이션을 import 하지 않아 에러가 발생하는 것이 발견되어 수정함