### PR TITLE
CORS에러 Allow Origin, Method 수정

### DIFF
--- a/src/main/java/com/jjbacsa/jjbacsabackend/etc/config/SecurityConfig.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/etc/config/SecurityConfig.java
@@ -87,9 +87,8 @@ public class SecurityConfig {
     CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
 
-        // TODO: front 웹 도메인으로 변경
-        configuration.setAllowedOriginPatterns(List.of("*"));
-        configuration.setAllowedMethods(List.of("HEAD","POST","GET","DELETE","PUT", "PATCH"));
+        configuration.setAllowedOriginPatterns(List.of("https://stage.jjbaksa.com", "https://api.stage.jjbaksa.com"));
+        configuration.setAllowedMethods(List.of("HEAD","POST","GET","DELETE","PUT", "PATCH", "OPTIONS"));
         configuration.setAllowedHeaders(List.of("*"));
         configuration.setAllowCredentials(true);
 


### PR DESCRIPTION
* Preflight Request에 대한 OPTIONS 메소드가 허용되지 않아 CORS 발생 -> OPTIONS 메소드 추가
* Origin을 프론트 도메인, api 도메인으로 제한