### PR TITLE
Preflight Request 거절로 인해 CustomCorsFilter로 변경

### DIFF
--- a/src/main/java/com/jjbacsa/jjbacsabackend/etc/filter/CustomCorsFilter.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/etc/filter/CustomCorsFilter.java
@@ -1,0 +1,39 @@
+package com.jjbacsa.jjbacsabackend.etc.filter;
+
+import com.jjbacsa.jjbacsabackend.etc.security.CustomCorsConfigSource;
+import org.springframework.web.cors.*;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.*;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+
+public class CustomCorsFilter extends OncePerRequestFilter {
+
+    private CorsProcessor processor = new DefaultCorsProcessor();
+    private final CorsConfigurationSource configSource;
+
+    public CustomCorsFilter(CustomCorsConfigSource customCorsConfigSource){
+        this.configSource = customCorsConfigSource.getCorsConfigurationSource();
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain)
+            throws ServletException, IOException {
+
+        CorsConfiguration corsConfiguration = this.configSource.getCorsConfiguration(request);
+        boolean isValid = this.processor.processRequest(corsConfiguration, request, response);
+        if (!isValid) {
+            return;
+        }
+        else if(CorsUtils.isPreFlightRequest(request)) {
+            response.setStatus(HttpServletResponse.SC_OK);
+        }
+        else filterChain.doFilter(request, response);
+    }
+
+}

--- a/src/main/java/com/jjbacsa/jjbacsabackend/etc/security/CustomCorsConfigSource.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/etc/security/CustomCorsConfigSource.java
@@ -1,0 +1,25 @@
+package com.jjbacsa.jjbacsabackend.etc.security;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
+
+@Component
+public class CustomCorsConfigSource {
+
+    public CorsConfigurationSource getCorsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+
+        configuration.setAllowedOriginPatterns(List.of("https://stage.jjbaksa.com", "https://api.stage.jjbaksa.com"));
+        configuration.setAllowedMethods(List.of("OPTIONS", "HEAD","POST","GET","DELETE","PUT", "PATCH"));
+        configuration.setAllowedHeaders(List.of("*"));
+        configuration.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
+}


### PR DESCRIPTION
Spring-framework에서 제공하는 CorsFilter는 Preflight Request에 대해 거절하도록 설정되어있다. 
우리 프로젝트는 웹 프론트와 API 서버를 분리하여 다른 도메인으로 통신하므로 서로 다른 Origin 간 요청에서 발생하는 Preflight Request에 200을 반환해야 하기 때문에
CustomCorsFilter로 변경하여 Preflight Request를 허용하고 allow origin을 제한하도록 설정한다.

* Spring-framework CorsFilter
https://github.com/spring-projects/spring-framework/blob/main/spring-web/src/main/java/org/springframework/web/filter/CorsFilter.java
