### PR TITLE
CORS 테스트

### DIFF
--- a/src/main/java/com/jjbacsa/jjbacsabackend/etc/security/CustomCorsConfigSource.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/etc/security/CustomCorsConfigSource.java
@@ -13,7 +13,7 @@ public class CustomCorsConfigSource {
     public CorsConfigurationSource getCorsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
 
-        configuration.setAllowedOriginPatterns(List.of("https://stage.jjbaksa.com", "https://api.stage.jjbaksa.com"));
+        configuration.setAllowedOriginPatterns(List.of("*"));
         configuration.setAllowedMethods(List.of("OPTIONS", "HEAD","POST","GET","DELETE","PUT", "PATCH"));
         configuration.setAllowedHeaders(List.of("*"));
         configuration.setAllowCredentials(true);


### PR DESCRIPTION
Custom CorsFilter를 적용했지만 여전히 CORS 에러가 발생하여 Preflight Request 문제인지 Origin 문제인지 확인하기 위해 allow Origin을 와일드카드로 하여 테스트한다