### PR TITLE
리뷰 정렬을 클라이언트가 설정할 수 있도록 수정

### DIFF
--- a/src/main/java/com/jjbacsa/jjbacsabackend/etc/dto/CustomPageRequest.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/etc/dto/CustomPageRequest.java
@@ -1,0 +1,41 @@
+package com.jjbacsa.jjbacsabackend.etc.dto;
+
+import io.swagger.annotations.ApiParam;
+import lombok.*;
+import org.hibernate.validator.constraints.Range;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+
+import javax.validation.constraints.Min;
+import javax.validation.constraints.Pattern;
+import java.util.Arrays;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CustomPageRequest {
+    @Builder.Default
+    @ApiParam("조회할 페이지")
+    @Min(value = 0, message = "page는 0이상 입니다.")
+    private int page = 0;
+    @Builder.Default
+    @ApiParam("페이지 크기")
+    @Range(min = 1, max = 100, message = "size의 범위는 1~100 사이 입니다.")
+    private int size = 10;
+    @Builder.Default
+    @ApiParam("정렬방식 - 내림차순, 오름차순")
+    private Sort.Direction direction = Sort.Direction.DESC;
+    @Builder.Default
+    @ApiParam("정렬 기준 지정")
+    @Pattern(regexp= "^[a-zA-Z,\\s]*$", message = "올바른 정렬 형식이 아닙니다.")
+    private String sort = "createdAt,id";
+
+    public PageRequest of(){
+        return PageRequest.of(page, size, direction,
+                Arrays.stream(sort.split(","))
+                        .map(s-> s.trim())
+                        .toArray(String[]::new));
+    }
+}

--- a/src/main/java/com/jjbacsa/jjbacsabackend/review/controller/ReviewController.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/review/controller/ReviewController.java
@@ -1,6 +1,7 @@
 package com.jjbacsa.jjbacsabackend.review.controller;
 
-import com.jjbacsa.jjbacsabackend.etc.annotations.Auth;
+import com.jjbacsa.jjbacsabackend.etc.annotations.ValidationGroups;
+import com.jjbacsa.jjbacsabackend.etc.dto.CustomPageRequest;
 import com.jjbacsa.jjbacsabackend.review.dto.request.ReviewRequest;
 import com.jjbacsa.jjbacsabackend.review.dto.response.ReviewDeleteResponse;
 import com.jjbacsa.jjbacsabackend.review.dto.response.ReviewResponse;
@@ -12,13 +13,11 @@ import io.swagger.annotations.Authorization;
 import lombok.RequiredArgsConstructor;
 import org.hibernate.validator.constraints.Range;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
@@ -39,7 +38,7 @@ public class ReviewController {
             authorizations = @Authorization(value = "Bearer + accessToken"))
     @PreAuthorize("hasRole('NORMAL')")
     @PostMapping(value = "/review", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<ReviewResponse> createReview(@ModelAttribute ReviewRequest reviewRequest) throws Exception {
+    public ResponseEntity<ReviewResponse> createReview(@Validated(ValidationGroups.Create.class) @ModelAttribute ReviewRequest reviewRequest) throws Exception {
         return new ResponseEntity<>(reviewService.createReview(reviewRequest), HttpStatus.CREATED);
     }
     @ApiOperation(
@@ -53,31 +52,43 @@ public class ReviewController {
 
     @ApiOperation(
             value = "내 리뷰 조회",
-            notes = "내가 작성한 리뷰를 모두 조회합니다.\n\n", authorizations = @Authorization(value = "Bearer + accessToken"))
+            notes = "내가 작성한 리뷰를 모두 조회합니다.\n\n"+
+                    "example : \n\n" +
+                    "{\n\n" +
+                    "       \"page\" : \"페이지 default: 0\"\n\n" +
+                    "       \"size\" : \"페이지 크기 default: 10\"\n\n" +
+                    "       \"direction\" : \"정렬 방식 DESC, ASC default: DESC\"\n\n" +
+                    "       \"sort\": \"정렬 기준 컬럼명 기재 ','로 우선순위 구분 default: createdAt,id 생성일시 기준, 생성일시가 같으면 id로 구분\"\n\n" +
+                    "}", authorizations = @Authorization(value = "Bearer + accessToken"))
     @PreAuthorize("hasRole('NORMAL')")
     @GetMapping(value = "/review")
-    public ResponseEntity<Page<ReviewResponse>> getMyReviews(@ApiParam("조회할 페이지") @RequestParam(value = "page", required = false, defaultValue = "0")Integer page, @ApiParam("페이징 사이즈") @RequestParam(value = "size", required=false, defaultValue="3")Integer size) throws Exception {
-        return new ResponseEntity<>(reviewService.getMyReviews(page, size), HttpStatus.OK);
+    public ResponseEntity<Page<ReviewResponse>> getMyReviews(@Validated CustomPageRequest pageable) throws Exception {
+        return new ResponseEntity<>(reviewService.getMyReviews(pageable.of()), HttpStatus.OK);
     }
 
-    // TODO: 관리자 권한으로 변경
     @ApiOperation(
             value = "상점에 대한 모든 리뷰 조회",
-            notes = "상점에 대한 모든 리뷰를 조회합니다.\n\n", authorizations = @Authorization(value = "Bearer +accessToken"))
-    @PreAuthorize("hasRole('NORMAL')")
+            notes = "상점에 대한 모든 리뷰를 조회합니다.\n\n"+
+                    "example : \n\n" +
+                    "{\n\n" +
+                    "       \"page\" : \"페이지 default: 0\"\n\n" +
+                    "       \"size\" : \"페이지 크기 default: 10\"\n\n" +
+                    "       \"direction\" : \"정렬 방식 DESC, ASC default: DESC\"\n\n" +
+                    "       \"sort\": \"정렬 기준 컬럼명 기재 ','로 우선순위 구분 default: createdAt,id 생성일시 기준, 생성일시가 같으면 id로 구분\"\n\n" +
+                    "}", authorizations = @Authorization(value = "Bearer +accessToken"))
+    @PreAuthorize("hasRole('ADMIN')")
     @GetMapping(value = "/review/search/shop/{shop-id}")
-    public ResponseEntity<Page<ReviewResponse>> searchShopReview(@ApiParam("조회할 상점id") @PathVariable("shop-id") Long shopId, @ApiParam("조회할 페이지") @RequestParam(value = "page", required = false, defaultValue = "0")Integer page, @ApiParam("페이징 사이즈") @RequestParam(value = "size", required=false, defaultValue="3")Integer size){
-        return new ResponseEntity<>(reviewService.searchShopReviews(shopId, page, size), HttpStatus.OK);
+    public ResponseEntity<Page<ReviewResponse>> searchShopReview(@ApiParam("조회할 상점id") @PathVariable("shop-id") Long shopId, @Validated CustomPageRequest pageable){
+        return new ResponseEntity<>(reviewService.searchShopReviews(shopId, pageable.of()), HttpStatus.OK);
     }
 
-    // TODO: 관리자 권한으로 변경
     @ApiOperation(
             value = "특정사용자가 작성한 모든 리뷰 조회",
             notes = "사용자에 대한 모든 리뷰를 조회합니다.\n\n", authorizations = @Authorization(value = "Bearer +accessToken"))
-    @PreAuthorize("hasRole('NORMAL')")
+    @PreAuthorize("hasRole('ADMIN')")
     @GetMapping(value = "/review/search/writer/{writer-id}")
-    public ResponseEntity<Page<ReviewResponse>>searchWriterReview(@ApiParam("작성자 id") @PathVariable("writer-id") Long writerId, @ApiParam("조회할 페이지") @RequestParam(value = "page", required = false, defaultValue = "0")Integer page, @ApiParam("페이징 사이즈") @RequestParam(value = "size", required=false, defaultValue="3")Integer size){
-        return new ResponseEntity<>(reviewService.searchWriterReviews(writerId, page, size), HttpStatus.OK);
+    public ResponseEntity<Page<ReviewResponse>>searchWriterReview(@ApiParam("작성자 id") @PathVariable("writer-id") Long writerId, @Validated CustomPageRequest pageable){
+        return new ResponseEntity<>(reviewService.searchWriterReviews(writerId, pageable.of()), HttpStatus.OK);
     }
 
     @ApiOperation(
@@ -94,10 +105,10 @@ public class ReviewController {
             notes = "리뷰를 수정합니다. MediaType은 MULTIPART_FORM_DATA_VALUE를 선택해주세요.\n\n" +
                     "example : \n\n" +
                     "{\n\n" +
-                    "       \"shopId\" : \"상점 id\"\n\n" +
                     "       \"content\" : \"내용\"\n\n" +
                     "       \"rate\" : \"별점\"\n\n" +
                     "       \"reviewImages\" : \"리뷰 이미지\"\n\n" +
+                    "       \"shopId\" : \"상점 id는 사용되지 않습니다.\"\n\n" +
                     "}",
             authorizations = @Authorization(value = "Bearer + accessToken"))
     @PreAuthorize("hasRole('NORMAL')")
@@ -111,8 +122,8 @@ public class ReviewController {
             notes = "팔로워가 작성한 리뷰를 조회합니다.\n\n", authorizations = @Authorization(value = "Bearer +accessToken"))
     @PreAuthorize("hasRole('NORMAL')")
     @GetMapping(value="/review/search/follower")
-    public ResponseEntity<Page<ReviewResponse>> searchFollowerReview(@ApiParam("팔로워 account") @RequestParam("follower-account") String account, @ApiParam("조회할 페이지") @RequestParam(value = "page", required = false, defaultValue = "0")Integer page, @ApiParam("페이징 사이즈") @RequestParam(value = "size", required=false, defaultValue="3")Integer size) throws Exception {
-        return new ResponseEntity<>(reviewService.searchFollowerReviews(account, page, size), HttpStatus.OK);
+    public ResponseEntity<Page<ReviewResponse>> searchFollowerReview(@ApiParam("팔로워 account") @RequestParam("follower-account") String account, @Validated CustomPageRequest pageable) throws Exception {
+        return new ResponseEntity<>(reviewService.searchFollowerReviews(account, pageable.of()), HttpStatus.OK);
     }
 
     @ApiOperation(
@@ -120,8 +131,8 @@ public class ReviewController {
             notes = "팔로워들이 작성한 모든 리뷰를 조회합니다.\n\n", authorizations = @Authorization(value = "Bearer +accessToken"))
     @PreAuthorize("hasRole('NORMAL')")
     @GetMapping(value="/review/follower")
-    public ResponseEntity<Page<ReviewResponse>> getFollowersReviews( @ApiParam("조회할 페이지") @RequestParam(value = "page", required = false, defaultValue = "0")Integer page, @ApiParam("페이징 사이즈") @RequestParam(value = "size", required=false, defaultValue="3")Integer size) throws Exception {
-        return new ResponseEntity<>(reviewService.getFollowersReviews(page, size), HttpStatus.OK);
+    public ResponseEntity<Page<ReviewResponse>> getFollowersReviews(@Validated CustomPageRequest pageable) throws Exception {
+        return new ResponseEntity<>(reviewService.getFollowersReviews(pageable.of()), HttpStatus.OK);
     }
 
     @ApiOperation(
@@ -129,8 +140,8 @@ public class ReviewController {
             notes = "특정 상점에 대해 팔로워들이 작성한 리뷰를 조회합니다.\n\n", authorizations = @Authorization(value = "Bearer +accessToken"))
     @PreAuthorize("hasRole('NORMAL')")
     @GetMapping(value="/review/search/shop/{shop-id}/follower")
-    public ResponseEntity<Page<ReviewResponse>> searchFollowersShopReviews(@ApiParam("조회할 상점id") @PathVariable("shop-id") Long shopId, @ApiParam("조회할 페이지") @RequestParam(value = "page", required = false, defaultValue = "0")Integer page, @ApiParam("페이징 사이즈") @RequestParam(value = "size", required=false, defaultValue="3")Integer size) throws Exception {
-        return new ResponseEntity<>(reviewService.searchFollowersShopReviews(shopId, page, size), HttpStatus.OK);
+    public ResponseEntity<Page<ReviewResponse>> searchFollowersShopReviews(@ApiParam("조회할 상점id") @PathVariable("shop-id") Long shopId, @Validated CustomPageRequest pageable) throws Exception {
+        return new ResponseEntity<>(reviewService.searchFollowersShopReviews(shopId, pageable.of()), HttpStatus.OK);
     }
 
     @ApiOperation(

--- a/src/main/java/com/jjbacsa/jjbacsabackend/review/controller/ReviewController.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/review/controller/ReviewController.java
@@ -84,7 +84,14 @@ public class ReviewController {
 
     @ApiOperation(
             value = "특정사용자가 작성한 모든 리뷰 조회",
-            notes = "사용자에 대한 모든 리뷰를 조회합니다.\n\n", authorizations = @Authorization(value = "Bearer +accessToken"))
+            notes = "사용자에 대한 모든 리뷰를 조회합니다.\n\n"+
+                    "example : \n\n" +
+                    "{\n\n" +
+                    "       \"page\" : \"페이지 default: 0\"\n\n" +
+                    "       \"size\" : \"페이지 크기 default: 10\"\n\n" +
+                    "       \"direction\" : \"정렬 방식 DESC, ASC default: DESC\"\n\n" +
+                    "       \"sort\": \"정렬 기준 컬럼명 기재 ','로 우선순위 구분 default: createdAt,id 생성일시 기준, 생성일시가 같으면 id로 구분\"\n\n" +
+                    "}", authorizations = @Authorization(value = "Bearer +accessToken"))
     @PreAuthorize("hasRole('ADMIN')")
     @GetMapping(value = "/review/search/writer/{writer-id}")
     public ResponseEntity<Page<ReviewResponse>>searchWriterReview(@ApiParam("작성자 id") @PathVariable("writer-id") Long writerId, @Validated CustomPageRequest pageable){
@@ -119,7 +126,14 @@ public class ReviewController {
 
     @ApiOperation(
             value = "팔로워 리뷰 조회",
-            notes = "팔로워가 작성한 리뷰를 조회합니다.\n\n", authorizations = @Authorization(value = "Bearer +accessToken"))
+            notes = "팔로워가 작성한 리뷰를 조회합니다.\n\n"+
+                    "example : \n\n" +
+                    "{\n\n" +
+                    "       \"page\" : \"페이지 default: 0\"\n\n" +
+                    "       \"size\" : \"페이지 크기 default: 10\"\n\n" +
+                    "       \"direction\" : \"정렬 방식 DESC, ASC default: DESC\"\n\n" +
+                    "       \"sort\": \"정렬 기준 컬럼명 기재 ','로 우선순위 구분 default: createdAt,id 생성일시 기준, 생성일시가 같으면 id로 구분\"\n\n" +
+                    "}", authorizations = @Authorization(value = "Bearer +accessToken"))
     @PreAuthorize("hasRole('NORMAL')")
     @GetMapping(value="/review/search/follower")
     public ResponseEntity<Page<ReviewResponse>> searchFollowerReview(@ApiParam("팔로워 account") @RequestParam("follower-account") String account, @Validated CustomPageRequest pageable) throws Exception {
@@ -128,7 +142,14 @@ public class ReviewController {
 
     @ApiOperation(
             value = "팔로워들이 작성한 모든 리뷰 조회",
-            notes = "팔로워들이 작성한 모든 리뷰를 조회합니다.\n\n", authorizations = @Authorization(value = "Bearer +accessToken"))
+            notes = "팔로워들이 작성한 모든 리뷰를 조회합니다.\n\n"+
+                    "example : \n\n" +
+                    "{\n\n" +
+                    "       \"page\" : \"페이지 default: 0\"\n\n" +
+                    "       \"size\" : \"페이지 크기 default: 10\"\n\n" +
+                    "       \"direction\" : \"정렬 방식 DESC, ASC default: DESC\"\n\n" +
+                    "       \"sort\": \"정렬 기준 컬럼명 기재 ','로 우선순위 구분 default: createdAt,id 생성일시 기준, 생성일시가 같으면 id로 구분\"\n\n" +
+                    "}", authorizations = @Authorization(value = "Bearer +accessToken"))
     @PreAuthorize("hasRole('NORMAL')")
     @GetMapping(value="/review/follower")
     public ResponseEntity<Page<ReviewResponse>> getFollowersReviews(@Validated CustomPageRequest pageable) throws Exception {
@@ -137,7 +158,14 @@ public class ReviewController {
 
     @ApiOperation(
             value = "특정 상점에 대해 팔로워들이 작성한 리뷰 조회",
-            notes = "특정 상점에 대해 팔로워들이 작성한 리뷰를 조회합니다.\n\n", authorizations = @Authorization(value = "Bearer +accessToken"))
+            notes = "특정 상점에 대해 팔로워들이 작성한 리뷰를 조회합니다.\n\n"+
+                    "example : \n\n" +
+                    "{\n\n" +
+                    "       \"page\" : \"페이지 default: 0\"\n\n" +
+                    "       \"size\" : \"페이지 크기 default: 10\"\n\n" +
+                    "       \"direction\" : \"정렬 방식 DESC, ASC default: DESC\"\n\n" +
+                    "       \"sort\": \"정렬 기준 컬럼명 기재 ','로 우선순위 구분 default: createdAt,id 생성일시 기준, 생성일시가 같으면 id로 구분\"\n\n" +
+                    "}", authorizations = @Authorization(value = "Bearer +accessToken"))
     @PreAuthorize("hasRole('NORMAL')")
     @GetMapping(value="/review/search/shop/{shop-id}/follower")
     public ResponseEntity<Page<ReviewResponse>> searchFollowersShopReviews(@ApiParam("조회할 상점id") @PathVariable("shop-id") Long shopId, @Validated CustomPageRequest pageable) throws Exception {

--- a/src/main/java/com/jjbacsa/jjbacsabackend/review/dto/request/ReviewRequest.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/review/dto/request/ReviewRequest.java
@@ -1,18 +1,25 @@
 package com.jjbacsa.jjbacsabackend.review.dto.request;
 
+import com.jjbacsa.jjbacsabackend.etc.annotations.ValidationGroups;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Range;
 import org.springframework.web.multipart.MultipartFile;
 
+import javax.validation.constraints.NotNull;
 import java.util.List;
 
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
 public class ReviewRequest {
+    @NotNull(groups = {ValidationGroups.Create.class}, message = "상점 id가 필요합니다.")
     private Long shopId;
+    @NotNull(groups = {ValidationGroups.Create.class}, message = "리뷰 내용을 입력해주세요.")
     private String content;
+    @Range(min = 0, max = 5, message = "별점의 범위는 0 ~ 5점 까지 입니다.")
+    @NotNull(groups = {ValidationGroups.Create.class}, message = "별점을 입력해주세요.")
     private Integer rate;
     private List<MultipartFile> reviewImages;
 }

--- a/src/main/java/com/jjbacsa/jjbacsabackend/review/service/ReviewService.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/review/service/ReviewService.java
@@ -13,13 +13,13 @@ public interface ReviewService {
     ReviewResponse modifyReview(ReviewRequest reviewRequest, Long reviewId) throws Exception;
     ReviewDeleteResponse deleteReview(Long reviewId) throws Exception;
     ReviewResponse getReview(Long reviewId);
-    Page<ReviewResponse> searchShopReviews(Long shopId, Integer page, Integer size);
-    Page<ReviewResponse> searchWriterReviews(Long writerId, Integer page, Integer size);
+    Page<ReviewResponse> searchShopReviews(Long shopId, Pageable pageable);
+    Page<ReviewResponse> searchWriterReviews(Long writerId, Pageable pageable);
 
-    Page<ReviewResponse> getMyReviews(Integer page, Integer size) throws Exception;
-    Page<ReviewResponse> getFollowersReviews(Integer page, Integer size) throws Exception;
-    Page<ReviewResponse> searchFollowerReviews(String followerAccount, Integer page, Integer size) throws Exception;
-    Page<ReviewResponse> searchFollowersShopReviews(Long shopId, Integer page, Integer size) throws Exception;
+    Page<ReviewResponse> getMyReviews(Pageable pageable) throws Exception;
+    Page<ReviewResponse> getFollowersReviews(Pageable pageable) throws Exception;
+    Page<ReviewResponse> searchFollowerReviews(String followerAccount, Pageable pageable) throws Exception;
+    Page<ReviewResponse> searchFollowersShopReviews(Long shopId, Pageable pageable) throws Exception;
 
     Page<ShopResponse> searchShopByReviewContentsAndFollowers (String cursor, String searchWord, Integer size) throws Exception;
 }

--- a/src/main/java/com/jjbacsa/jjbacsabackend/review/serviceImpl/ReviewServiceImpl.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/review/serviceImpl/ReviewServiceImpl.java
@@ -21,7 +21,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -92,51 +92,45 @@ public class ReviewServiceImpl implements ReviewService {
 
     @Override
     @Transactional(readOnly = true)
-    public Page<ReviewResponse> searchShopReviews(Long shopId, Integer page, Integer size) {
-        PageRequest pageRequest = PageRequest.of(page, size, Sort.Direction.DESC, "createdAt");
-        return reviewRepository.findAllByShopId(shopId, pageRequest).map(ReviewMapper.INSTANCE::fromReviewEntity);
+    public Page<ReviewResponse> searchShopReviews(Long shopId, Pageable pageable) {
+        return reviewRepository.findAllByShopId(shopId, pageable).map(ReviewMapper.INSTANCE::fromReviewEntity);
     }
 
     @Override
     @Transactional(readOnly = true)
-    public Page<ReviewResponse> searchWriterReviews(Long writerId,  Integer page, Integer size){
-        PageRequest pageRequest = PageRequest.of(page, size, Sort.Direction.DESC, "createdAt");
-        return reviewRepository.findAllByWriterId(writerId, pageRequest).map(ReviewMapper.INSTANCE::fromReviewEntity);
+    public Page<ReviewResponse> searchWriterReviews(Long writerId,  Pageable pageable){
+        return reviewRepository.findAllByWriterId(writerId, pageable).map(ReviewMapper.INSTANCE::fromReviewEntity);
     }
     @Override
     @Transactional(readOnly = true)
-    public Page<ReviewResponse> getMyReviews(Integer page, Integer size) throws Exception {
+    public Page<ReviewResponse> getMyReviews(Pageable pageable) throws Exception {
         UserEntity user = userService.getLoginUser();
-        PageRequest pageRequest = PageRequest.of(page, size, Sort.Direction.DESC, "createdAt");
-        return reviewRepository.findAllByWriterId(user.getId(), pageRequest).map(ReviewMapper.INSTANCE::fromReviewEntity);
+        return reviewRepository.findAllByWriterId(user.getId(), pageable).map(ReviewMapper.INSTANCE::fromReviewEntity);
     }
 
     @Override
     @Transactional(readOnly = true)
-    public Page<ReviewResponse> getFollowersReviews(Integer page, Integer size) throws Exception {
+    public Page<ReviewResponse> getFollowersReviews(Pageable pageable) throws Exception {
         UserEntity user = userService.getLoginUser();
-        PageRequest pageRequest = PageRequest.of(page, size, Sort.Direction.DESC, "createdAt");
-        return reviewRepository.findAllFriendsReview(user.getId(), pageRequest).map(ReviewResponse::from);
+        return reviewRepository.findAllFriendsReview(user.getId(), pageable).map(ReviewResponse::from);
     }
 
     @Override
     @Transactional(readOnly = true)
-    public Page<ReviewResponse> searchFollowerReviews(String followerAccount, Integer page, Integer size) throws Exception {
+    public Page<ReviewResponse> searchFollowerReviews(String followerAccount, Pageable pageable) throws Exception {
         UserEntity user = userService.getLoginUser();
-        PageRequest pageRequest = PageRequest.of(page, size, Sort.Direction.DESC, "createdAt");
         UserEntity follower = userService.getUserByAccount(followerAccount);
         if(followService.existsByUserAndFollower(user, follower)){
-            return reviewRepository.findAllByFollowerId(follower.getId(), pageRequest).map(ReviewResponse::from);
+            return reviewRepository.findAllByFollowerId(follower.getId(), pageable).map(ReviewResponse::from);
         }
         else throw new RequestInputException(ErrorMessage.NOT_FOLLOWED_EXCEPTION);
     }
 
     @Override
     @Transactional(readOnly = true)
-    public Page<ReviewResponse> searchFollowersShopReviews(Long shopId, Integer page, Integer size) throws Exception {
+    public Page<ReviewResponse> searchFollowersShopReviews(Long shopId, Pageable pageable) throws Exception {
         UserEntity user = userService.getLoginUser();
-        PageRequest pageRequest = PageRequest.of(page, size, Sort.Direction.DESC, "createdAt");
-        return reviewRepository.findAllFollowersReviewsByShopId(user.getId(), shopId, pageRequest).map(ReviewResponse::from);
+        return reviewRepository.findAllFollowersReviewsByShopId(user.getId(), shopId, pageable).map(ReviewResponse::from);
     }
 
     @Override

--- a/src/main/java/com/jjbacsa/jjbacsabackend/util/QueryDslUtil.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/util/QueryDslUtil.java
@@ -1,0 +1,13 @@
+package com.jjbacsa.jjbacsabackend.util;
+
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.Expressions;
+
+public class QueryDslUtil {
+    public static OrderSpecifier<?> getSortedColumn(Order order, Path<?> parent, String fieldName){
+        Path<Object> fieldPath = Expressions.path(Object.class, parent, fieldName);
+        return new OrderSpecifier(order, fieldPath);
+    }
+}

--- a/src/test/java/com/jjbacsa/jjbacsabackend/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/jjbacsa/jjbacsabackend/review/service/ReviewServiceTest.java
@@ -1,6 +1,7 @@
 package com.jjbacsa.jjbacsabackend.review.service;
 
 
+import com.jjbacsa.jjbacsabackend.etc.dto.CustomPageRequest;
 import com.jjbacsa.jjbacsabackend.follow.repository.FollowRepository;
 import com.jjbacsa.jjbacsabackend.follow.serviceimpl.FollowServiceImpl;
 import com.jjbacsa.jjbacsabackend.review.dto.request.ReviewRequest;
@@ -22,6 +23,9 @@ import org.junit.jupiter.api.*;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -109,11 +113,10 @@ public class ReviewServiceTest {
     void givenShopId_whenSearchingReviews_thenReturnsReviewPage(){
         // Given
         Long shopId = 1L;
-        Integer page = 0;
-        Integer size = 3;
+        PageRequest pageRequest = createPageRequest();
         // When
-        Page<ReviewResponse> reviews = reviewService.searchShopReviews(shopId, page, size);
-        Page<ReviewResponse> emptyReviews = reviewService.searchShopReviews(0L, page, size);
+        Page<ReviewResponse> reviews = reviewService.searchShopReviews(shopId, pageRequest);
+        Page<ReviewResponse> emptyReviews = reviewService.searchShopReviews(0L, pageRequest);
 
         // Then
         assertThat(reviews).isNotEmpty();
@@ -126,12 +129,11 @@ public class ReviewServiceTest {
     void givenUserId_whenSearchingReviews_thenReturnsReviewPage(){
         // Given
         Long writerId = 1L;
-        Integer page = 0;
-        Integer size = 3;
+        PageRequest pageRequest = createPageRequest();
 
         // When
-        Page<ReviewResponse> reviews = reviewService.searchWriterReviews(writerId, page, size);
-        Page<ReviewResponse> emptyReviews = reviewService.searchWriterReviews(0L, page, size);
+        Page<ReviewResponse> reviews = reviewService.searchWriterReviews(writerId, pageRequest);
+        Page<ReviewResponse> emptyReviews = reviewService.searchWriterReviews(0L, pageRequest);
 
         // Then
         assertThat(reviews).isNotEmpty();
@@ -199,18 +201,18 @@ public class ReviewServiceTest {
         // Given
         user = userRepository.getById(1L);
         user2 = userRepository.getById(2L);
-        Integer page = 0;
-        Integer size = 3;
+        PageRequest pageRequest = createPageRequest();
+
         // When
         testLogin(user);
-        Page<ReviewResponse> reviews = reviewService.searchFollowerReviews(user2.getAccount(), page, size);
+        Page<ReviewResponse> reviews = reviewService.searchFollowerReviews(user2.getAccount(), pageRequest);
         // Then
         assertThat(reviews).isNotEmpty();
         assertThat(reviews).allMatch(review -> review.getUserReviewResponse().getId().equals(user2.getId()));
 
         // 팔로워가 아닌 경우
         user3 = userRepository.getById(3L);
-        assertThrows(RuntimeException.class, () -> reviewService.searchFollowerReviews(user3.getAccount(), page, size));
+        assertThrows(RuntimeException.class, () -> reviewService.searchFollowerReviews(user3.getAccount(), pageRequest));
     }
 
     @DisplayName("사용자의 모든 친구에 대해 리뷰 페이지를 반환한다.")
@@ -218,11 +220,11 @@ public class ReviewServiceTest {
     void givenUser_whenSearchFollowerReviews_thenReturnReviewPage() throws Exception {
         // Given
         user = userRepository.getById(1L);
-        Integer page = 0;
-        Integer size = 3;
+        PageRequest pageRequest = createPageRequest();
+
         // When
         testLogin(user);
-        Page<ReviewResponse> reviews = reviewService.getFollowersReviews(page, size);
+        Page<ReviewResponse> reviews = reviewService.getFollowersReviews(pageRequest);
         // Then
         assertThat(reviews).isNotEmpty();
         assertThat(reviews).allMatch(
@@ -236,9 +238,10 @@ public class ReviewServiceTest {
         user = userRepository.getById(1L);
         Integer page = 0;
         Integer size = 3;
+        PageRequest pageRequest = PageRequest.of(page, size, Sort.Direction.DESC, "createdAt");
         // When
         testLogin(user);
-        Page<ReviewResponse> reviews = reviewService.getMyReviews(page, size);
+        Page<ReviewResponse> reviews = reviewService.getMyReviews(pageRequest);
         // Then
         assertThat(reviews).isNotEmpty();
         assertThat(reviews).allMatch(
@@ -251,11 +254,11 @@ public class ReviewServiceTest {
         // Given
         user = userRepository.getById(1L);
         Long shopId = 1L;
-        Integer page = 0;
-        Integer size = 3;
+        PageRequest pageRequest = createPageRequest();
+
         // When
         testLogin(user);
-        Page<ReviewResponse> reviews = reviewService.searchFollowersShopReviews(shopId, page, size);
+        Page<ReviewResponse> reviews = reviewService.searchFollowersShopReviews(shopId, pageRequest);
         // Then
         assertThat(reviews).isNotEmpty();
         assertThat(reviews).allMatch(
@@ -267,7 +270,7 @@ public class ReviewServiceTest {
 
         // 친구가 작성한 리뷰가 없는 경우
         Long shopId2 = 2L;
-        Page<ReviewResponse> emptyReviews = reviewService.searchFollowersShopReviews(shopId2, page, size);
+        Page<ReviewResponse> emptyReviews = reviewService.searchFollowersShopReviews(shopId2, pageRequest);
         assertThat(emptyReviews).isEmpty();
 
     }
@@ -316,4 +319,7 @@ public class ReviewServiceTest {
         SecurityContextHolder.getContext().setAuthentication(auth);
     }
 
+    private PageRequest createPageRequest(){
+        return CustomPageRequest.builder().build().of();
+    }
 }


### PR DESCRIPTION
#68

리뷰 페이징을 page와 size만 입력받는 것이 아니라, 정렬 까지 선택할 수 있도록 변경하였음
Pageable로 입력받으려고 했으나, page, size, 정렬 기준에 대한 validation이 필요해 CustomPageRequest를 만들어 validation 하였음
QueryDsl에 정렬 기준을 입력받아서 설정하는 부분이 조금 까다로워 Util과 정렬 기준인 order를 뽑아오는 메서드를 생성해 해결하였음

추가로 Swagger 문서 내용 추가 및 ReviewRequest에 대한 validation을 추가함