### PR TITLE
Post 페이징 및 정렬 수정

### DIFF
--- a/src/main/java/com/jjbacsa/jjbacsabackend/JjbacsaBackendApplication.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/JjbacsaBackendApplication.java
@@ -2,8 +2,10 @@ package com.jjbacsa.jjbacsabackend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class JjbacsaBackendApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/jjbacsa/jjbacsabackend/etc/annotations/ValidationGroups.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/etc/annotations/ValidationGroups.java
@@ -11,5 +11,7 @@ public final class ValidationGroups {
 
     public interface Login extends Default {};
 
-    public interface Get extends Default {};
+    public interface NormalCreate extends Default {};
+    public interface AdminCreate extends Default {};
+
 }

--- a/src/main/java/com/jjbacsa/jjbacsabackend/etc/entity/BaseEntity.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/etc/entity/BaseEntity.java
@@ -7,6 +7,7 @@ import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.persistence.*;
 import java.util.Date;
@@ -15,6 +16,7 @@ import java.util.Date;
 @NoArgsConstructor
 @SuperBuilder(toBuilder = true)
 @MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
 public abstract class BaseEntity {
 
     @Id
@@ -23,12 +25,12 @@ public abstract class BaseEntity {
     protected Long id;
 
     @Temporal(TemporalType.TIMESTAMP)
-    @Column(name = "created_at", nullable = false, updatable = false, insertable = false)
+    @Column(name = "created_at", nullable = false, updatable = false)
     @CreatedDate
     protected Date createdAt;
 
     @Temporal(TemporalType.TIMESTAMP)
-    @Column(name = "updated_at", nullable = false, updatable = false, insertable = false)
+    @Column(name = "updated_at", nullable = false)
     @LastModifiedDate
     protected Date updatedAt;
 

--- a/src/main/java/com/jjbacsa/jjbacsabackend/etc/enums/BoardType.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/etc/enums/BoardType.java
@@ -2,7 +2,7 @@ package com.jjbacsa.jjbacsabackend.etc.enums;
 
 
 public enum BoardType {
-    NOTICE("NOTICE"), FAQ("FAQ"), INQUIRY("INQUIRY");
+    NOTICE("NOTICE"), FAQ("FAQ"), INQUIRY("INQUIRY"), POWER_NOTICE("POWER_NOTICE");
 
     String boardType;
 

--- a/src/main/java/com/jjbacsa/jjbacsabackend/post/controller/PostController.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/post/controller/PostController.java
@@ -1,13 +1,11 @@
 package com.jjbacsa.jjbacsabackend.post.controller;
 
 import com.jjbacsa.jjbacsabackend.etc.annotations.ValidationGroups;
+import com.jjbacsa.jjbacsabackend.etc.dto.CustomPageRequest;
 import com.jjbacsa.jjbacsabackend.post.dto.request.PostRequest;
 import com.jjbacsa.jjbacsabackend.post.dto.response.PostResponse;
 import com.jjbacsa.jjbacsabackend.post.service.PostService;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiParam;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
@@ -15,6 +13,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+
+import javax.validation.constraints.Pattern;
 
 @RequiredArgsConstructor
 @RestController
@@ -24,7 +24,10 @@ public class PostController {
 
     @ApiOperation(
             value = "Post 조회",
-            notes = "post-id : 조회할 Post의 id")
+            notes = "Post를 조회합니다.\n\n" +
+                    "{\n\n" +
+                    "       \"postId\" : \"조회할 Post의 id\"\"\n\n" +
+                    "}")
     @ApiResponses({
             @ApiResponse(code = 200,
                 message = "읽어온 Post 정보",
@@ -38,12 +41,12 @@ public class PostController {
     @ApiOperation(
             value = "FAQ, NOTICE 작성",
             notes = "Post를 작성합니다.\n\n" +
-                    "ADMIN 권한이 필요합니다.\n\n\t" +
-                    "필요한 필드\n\n\t" +
-                    "{\n\n     " +
-                    "title : 제목,\n\n     " +
-                    "content : 내용,\n\n     " +
-                    "boardType : Post 타입(FAQ, NOTICE) \n\n\t}")
+                    "ADMIN 권한이 필요합니다.\n\n" +
+                    "{\n\n" +
+                    "       \"title\" : \"제목\"\n\n" +
+                    "       \"content\" : \"내용\"\n\n"+
+                    "       \"boardType\" : \"NOTICE, POWER_NOTICE, FAQ\"\n\n"+
+                    "}", authorizations = @Authorization(value = "Bearer +accessToken"))
     @ApiResponses({
             @ApiResponse(code = 201,
                     message = "작성한 Post 정보",
@@ -51,18 +54,19 @@ public class PostController {
     })
     @PreAuthorize("hasRole('ADMIN')")
     @PostMapping(value = "/admin/post")
-    public ResponseEntity<PostResponse> create(@Validated(ValidationGroups.Create.class) @RequestBody PostRequest postRequest){
+    public ResponseEntity<PostResponse> create(@Validated(ValidationGroups.AdminCreate.class) @RequestBody PostRequest postRequest){
         return new ResponseEntity<>(postService.createPost(postRequest), HttpStatus.CREATED);
     }
 
     @ApiOperation(
             value = "FAQ, NOTICE 수정",
             notes = "Post를 수정합니다.\n\n" +
-                    "ADMIN 권한이 필요합니다.\n\n\t" +
-                    "수정할 수 있는 필드\n\n\t" +
-                    "{\n\n     " +
-                    "title : 제목,\n\n     " +
-                    "content : 내용 \n\n\t}     ")
+                    "ADMIN 권한이 필요합니다.\n\n" +
+                    "{\n\n" +
+                    "       \"postId\" : \"삭제할 Post의 id\"\"\n\n" +
+                    "       \"title\" : \"제목\"\n\n" +
+                    "       \"content\" : \"내용\"\n\n"+
+                    "}", authorizations = @Authorization(value = "Bearer +accessToken"))
     @ApiResponses({
             @ApiResponse(code = 200,
                     message = "수정한 Post 정보",
@@ -77,8 +81,9 @@ public class PostController {
     @ApiOperation(
             value = "FAQ, NOTICE 삭제",
             notes = "ADMIN 권한이 필요합니다.\n\n" +
-                    "post-id : 삭제할 Post id"
-                    )
+                    "{\n\n" +
+                    "       \"postId\" : \"삭제할 Post의 id\"\"\n\n" +
+                    "}", authorizations = @Authorization(value = "Bearer +accessToken"))
     @ApiResponses({
             @ApiResponse(code = 204,
                     message = "반환값 없음")
@@ -92,17 +97,22 @@ public class PostController {
 
     @ApiOperation(
             value = "Post 조회",
-            notes = "boardType : 조회할 Post의 id\n\n" +
-                    "page: 조회할 Post page\n\n" +
-                    "size: page의 size")
+            notes = "Post를 조회합니다.\n\n"+
+                    "example : \n\n"+
+                    "{\n\n"+
+                    "       \"boardType\" : \"BoardType은 NOTICE(공지) / FAQ, INQUERY는 문의하기페이지에 같이 게시)\"\n\n" +
+                    "       \"page\" : \"페이지 default: 0\"\n\n" +
+                    "       \"size\" : \"페이지 크기 default: 10\"\n\n" +
+                    "       \"sort\": \"정렬 기준은 작성일 기준이며, POWER_NOTICE부터, 문의하기는 FAQ부터 반환됩니다. 값을 입력하지 않으셔도 됩니다.\"\n\n" +
+                    "}", authorizations = @Authorization(value = "Bearer +accessToken"))
     @ApiResponses({
             @ApiResponse(code = 200,
                     message = "Post Page",
                     response = Page.class)
     })
     @GetMapping(value = "/post")
-    public ResponseEntity<Page<PostResponse>> getPosts(@RequestParam String boardType, @ApiParam("조회할 페이지") @RequestParam(value = "page", required = false, defaultValue = "0")Integer page, @ApiParam("페이징 사이즈") @RequestParam(value = "size", required = false, defaultValue = "3")Integer size){
-        return new ResponseEntity<>(postService.getPosts(boardType, page, size), HttpStatus.OK);
+    public ResponseEntity<Page<PostResponse>> getPosts(@RequestParam @Pattern(regexp = "^(FAQ|NOTICE|INQUIRY|POWER_NOTICE)$", message = "올바른 게시글 타입이 아닙니다.") String boardType, @Validated CustomPageRequest pageable){
+        return new ResponseEntity<>(postService.getPosts(boardType, pageable.of()), HttpStatus.OK);
     }
 
 }

--- a/src/main/java/com/jjbacsa/jjbacsabackend/post/dto/request/PostRequest.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/post/dto/request/PostRequest.java
@@ -13,15 +13,18 @@ import javax.validation.constraints.Pattern;
 @NoArgsConstructor
 public class PostRequest {
     @ApiModelProperty(example = "title")
-    @NotNull(groups = {ValidationGroups.Create.class})
+    @NotNull(groups = {ValidationGroups.AdminCreate.class, ValidationGroups.NormalCreate.class})
     private String title;
 
     @ApiModelProperty(example = "content")
+    @NotNull(groups = {ValidationGroups.AdminCreate.class, ValidationGroups.NormalCreate.class})
     private String content;
 
     @ApiModelProperty(example = "NOTICE")
-    @Pattern(regexp = "^(FAQ|NOTICE|INQUIRY)$", message = "올바른 게시글 타입이 아닙니다.",
-    groups = {ValidationGroups.Create.class, ValidationGroups.Get.class})
-    @NotNull(groups = {ValidationGroups.Create.class, ValidationGroups.Get.class})
+    @Pattern(regexp = "^(FAQ|NOTICE|INQUIRY|POWER_NOTICE)$", message = "올바른 게시글 타입이 아닙니다.",
+            groups = {ValidationGroups.AdminCreate.class})
+    @Pattern(regexp = "^(INQUIRY)$", message = "올바른 게시글 타입이 아닙니다.",
+            groups = {ValidationGroups.NormalCreate.class})
+    @NotNull(groups = {ValidationGroups.Create.class})
     private String boardType;
 }

--- a/src/main/java/com/jjbacsa/jjbacsabackend/post/dto/response/PostResponse.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/post/dto/response/PostResponse.java
@@ -4,6 +4,9 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
@@ -11,4 +14,10 @@ public class PostResponse {
     private String title;
     private String content;
     private String boardType;
+    private String createdAt;
+
+    public void setCreatedAt(Date createAt){
+        SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd");
+        this.createdAt = format.format(createAt);
+    }
 }

--- a/src/main/java/com/jjbacsa/jjbacsabackend/post/repository/querydsl/DslPostRepository.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/post/repository/querydsl/DslPostRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.domain.Pageable;
 
 public interface DslPostRepository {
 
-    Page<PostEntity> findAllPosts(String boardType, Pageable pageable);
-
+    Page<PostEntity> findAllNotices(Pageable pageable);
+    Page<PostEntity> findAllInquiries(Pageable pageable);
 
 }

--- a/src/main/java/com/jjbacsa/jjbacsabackend/post/repository/querydsl/DslPostRepositoryImpl.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/post/repository/querydsl/DslPostRepositoryImpl.java
@@ -3,6 +3,10 @@ package com.jjbacsa.jjbacsabackend.post.repository.querydsl;
 import com.jjbacsa.jjbacsabackend.etc.enums.BoardType;
 import com.jjbacsa.jjbacsabackend.post.entity.PostEntity;
 import com.jjbacsa.jjbacsabackend.post.entity.QPostEntity;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.springframework.data.domain.Page;
@@ -11,6 +15,8 @@ import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport
 import org.springframework.data.support.PageableExecutionUtils;
 
 import java.util.List;
+
+import static org.mockito.ArgumentMatchers.eq;
 
 public class DslPostRepositoryImpl extends QuerydslRepositorySupport implements DslPostRepository {
     private final JPAQueryFactory queryFactory;
@@ -22,22 +28,40 @@ public class DslPostRepositoryImpl extends QuerydslRepositorySupport implements 
     }
 
     @Override
-    public Page<PostEntity> findAllPosts(String boardType, Pageable pageable) {
-
+    public Page<PostEntity> findAllNotices(Pageable pageable) {
+        OrderSpecifier<?>[] order = new OrderSpecifier[] {
+                orderByEnum(BoardType.POWER_NOTICE),
+                post.createdAt.desc(),
+                post.id.desc()
+        };
         List<PostEntity> postEntities = queryFactory
                 .selectFrom(post)
-                .where(post.boardType.eq(BoardType.valueOf(boardType)))
+                .where(post.boardType.in(BoardType.POWER_NOTICE, BoardType.NOTICE))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
-                .orderBy(post.createdAt.desc())
+                .orderBy(order)
                 .fetch();
 
         JPAQuery<Long> countQuery = queryFactory
                 .select(post.count())
                 .from(post)
-                .where(post.boardType.eq(BoardType.FAQ));
+                .where(post.boardType.in(BoardType.POWER_NOTICE, BoardType.NOTICE));
 
         return PageableExecutionUtils.getPage(postEntities, pageable, countQuery::fetchOne);
+    }
+
+    // Todo: INQUIRY 기능 구현 후 구현
+    @Override
+    public Page<PostEntity> findAllInquiries(Pageable pageable) {
+        return Page.empty();
+    }
+
+    private OrderSpecifier<Integer> orderByEnum(BoardType boardType) {
+        NumberExpression<Integer> cases = new CaseBuilder()
+                .when(post.boardType.eq(boardType))
+                        .then(1)
+                .otherwise(2);
+        return new OrderSpecifier<>(Order.ASC, cases);
     }
 
 }

--- a/src/main/java/com/jjbacsa/jjbacsabackend/post/service/PostService.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/post/service/PostService.java
@@ -1,14 +1,16 @@
 package com.jjbacsa.jjbacsabackend.post.service;
 
+import com.jjbacsa.jjbacsabackend.etc.dto.CustomPageRequest;
 import com.jjbacsa.jjbacsabackend.post.dto.request.PostRequest;
 import com.jjbacsa.jjbacsabackend.post.dto.response.PostResponse;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface PostService {
     PostResponse getPost(Long postId);
     PostResponse createPost(PostRequest postRequest);
     PostResponse modifyAdminPost(PostRequest postRequest, Long postId);
     void deletePost(Long postId);
-    Page<PostResponse> getPosts(String boardType, Integer page, Integer size);
+    Page<PostResponse> getPosts(String boardType, Pageable pageable);
 
 }

--- a/src/main/java/com/jjbacsa/jjbacsabackend/post/serviceImpl/PostServiceImpl.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/post/serviceImpl/PostServiceImpl.java
@@ -1,5 +1,6 @@
 package com.jjbacsa.jjbacsabackend.post.serviceImpl;
 
+import com.jjbacsa.jjbacsabackend.etc.enums.BoardType;
 import com.jjbacsa.jjbacsabackend.etc.enums.ErrorMessage;
 import com.jjbacsa.jjbacsabackend.etc.exception.RequestInputException;
 import com.jjbacsa.jjbacsabackend.post.dto.request.PostRequest;
@@ -11,8 +12,7 @@ import com.jjbacsa.jjbacsabackend.post.service.PostService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -60,9 +60,11 @@ public class PostServiceImpl implements PostService {
     }
 
     @Override
-    public Page<PostResponse> getPosts(String boardType, Integer page, Integer size) {
-        PageRequest pageRequest = PageRequest.of(page, size, Sort.Direction.DESC, "createdAt");
-        return postRepository.findAllPosts(boardType, pageRequest).map(PostMapper.INSTANCE::toPostResponse);
+    public Page<PostResponse> getPosts(String boardType, Pageable pageable) {
+        if(boardType.equals(BoardType.NOTICE.getBoardType()) || boardType.equals(BoardType.POWER_NOTICE.getBoardType())){
+            return postRepository.findAllNotices(pageable).map(PostMapper.INSTANCE::toPostResponse);
+        }
+        else return postRepository.findAllInquiries(pageable).map(PostMapper.INSTANCE::toPostResponse);
     }
 
     private PostEntity createPostEntity(PostRequest postRequest) {

--- a/src/test/java/com/jjbacsa/jjbacsabackend/post/controller/PostControllerTest.java
+++ b/src/test/java/com/jjbacsa/jjbacsabackend/post/controller/PostControllerTest.java
@@ -2,6 +2,7 @@ package com.jjbacsa.jjbacsabackend.post.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jjbacsa.jjbacsabackend.annotation.WithMockCustomUser;
+import com.jjbacsa.jjbacsabackend.etc.dto.CustomPageRequest;
 import com.jjbacsa.jjbacsabackend.etc.enums.BoardType;
 import com.jjbacsa.jjbacsabackend.etc.enums.UserType;
 import com.jjbacsa.jjbacsabackend.post.dto.request.PostRequest;
@@ -16,6 +17,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestConstructor;
@@ -107,16 +109,16 @@ public class PostControllerTest {
     @MethodSource
     @ParameterizedTest(name="[BoardType] \"{0}\"")
     void givenBoardType_whenGetPosts_thenPostsPage(String boardType) throws Exception {
-        int page = 0;
-        int size = 3;
+        PageRequest pageRequest = createPageRequest();
+
 
         mockMvc.perform(get("/post")
                         .queryParam("boardType", boardType)
-                        .queryParam("page", String.valueOf(page))
-                        .queryParam("size", String.valueOf(size))
+                        .queryParam("page", String.valueOf(pageRequest.getOffset()))
+                        .queryParam("size", String.valueOf(pageRequest.getPageSize()))
                 ).andDo(print())
                 .andExpect(status().isOk());
-        then(postService).should().getPosts(boardType, page, size);
+        then(postService).should().getPosts(boardType, pageRequest);
     }
     static Stream<Arguments> givenBoardType_whenGetPosts_thenPostsPage(){return getBoardType();}
 
@@ -146,7 +148,11 @@ public class PostControllerTest {
     private static Stream<Arguments> getBoardType(){
         return Stream.of(
                 arguments(BoardType.NOTICE.getBoardType()),
+                arguments(BoardType.POWER_NOTICE.getBoardType()),
                 arguments(BoardType.FAQ.getBoardType())
-        );
+                );
+    }
+    private PageRequest createPageRequest(){
+        return CustomPageRequest.builder().build().of();
     }
 }


### PR DESCRIPTION

- 페이징 방식 수정
- 정렬 방식 수정
- PostResponse에 `작성일: createdAt` 추가
- `createdAt`을 추가하면서 `게시글 생성 시` JPA 영속성, 생명 주기에 의해 createdAt에서 NPE가 발생하여 JPA Auditing 도입

This closes #68 