### PR TITLE
User 검색 시 팔로우 상태 값 추가

### DIFF
--- a/src/main/java/com/jjbacsa/jjbacsabackend/etc/enums/FollowedType.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/etc/enums/FollowedType.java
@@ -1,0 +1,5 @@
+package com.jjbacsa.jjbacsabackend.etc.enums;
+
+public enum FollowedType {
+    NONE,REQUESTED,FOLLOWED
+}

--- a/src/main/java/com/jjbacsa/jjbacsabackend/user/controller/UserController.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/user/controller/UserController.java
@@ -7,6 +7,7 @@ import com.jjbacsa.jjbacsabackend.etc.exception.RequestInputException;
 import com.jjbacsa.jjbacsabackend.user.dto.EmailRequest;
 import com.jjbacsa.jjbacsabackend.user.dto.UserRequest;
 import com.jjbacsa.jjbacsabackend.user.dto.UserResponse;
+import com.jjbacsa.jjbacsabackend.user.dto.UserResponseWithFollowedType;
 import com.jjbacsa.jjbacsabackend.user.service.InternalEmailService;
 import com.jjbacsa.jjbacsabackend.user.service.UserService;
 import com.jjbacsa.jjbacsabackend.user.serviceImpl.OAuth2UserServiceImpl;
@@ -153,7 +154,7 @@ public class UserController {
                     responseContainer = "Page")
     })
     @GetMapping("/users")
-    public ResponseEntity<Page<UserResponse>> searchUsers(
+    public ResponseEntity<Page<UserResponseWithFollowedType>> searchUsers(
             @Size(min = 1, max = 20, message = "닉네임은 1~20글자까지 검색할 수 있습니다.") @RequestParam String keyword,
             @ApiParam("가져올 데이터 수(1~100)") @Range(min = 0, max = 100, message = "올바르지 않은 값입니다.")
             @RequestParam(required = false, defaultValue = "20") Integer pageSize,

--- a/src/main/java/com/jjbacsa/jjbacsabackend/user/dto/UserResponseWithFollowedType.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/user/dto/UserResponseWithFollowedType.java
@@ -1,0 +1,44 @@
+package com.jjbacsa.jjbacsabackend.user.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.jjbacsa.jjbacsabackend.etc.enums.FollowedType;
+import com.jjbacsa.jjbacsabackend.etc.enums.OAuthType;
+import com.jjbacsa.jjbacsabackend.etc.enums.UserType;
+import com.jjbacsa.jjbacsabackend.image.dto.response.ImageResponse;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserResponseWithFollowedType {
+    @ApiModelProperty(notes = "유저 고유 id", example = "1")
+    private Long id;
+
+    @ApiModelProperty(notes = "유저 계정(영문/숫자 1~20글자)", example = "jjbcsa123")
+    private String account;
+
+    @ApiModelProperty(notes = "유저 닉네임(영문/한글/숫자 1~20글자)", example = "쩝쩝bacsa123")
+    private String nickname;
+
+    @ApiModelProperty(notes = "유저 계정", example = "jjbcsa@naver.com")
+    private String email;
+
+    private ImageResponse profileImage;
+
+    @ApiModelProperty(notes = "OAuth 타입", example = "NAVER")
+    private OAuthType oAuthType;
+
+    @ApiModelProperty(notes = "유저 타입", example = "NORMAL")
+    private UserType userType;
+
+    private UserCountResponse userCountResponse;
+
+    @ApiModelProperty(notes = "팔로우 상태", example = "NONE, REQUESTED, FOLLOWED")
+    private FollowedType followedType;
+}

--- a/src/main/java/com/jjbacsa/jjbacsabackend/user/mapper/UserMapper.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/user/mapper/UserMapper.java
@@ -1,7 +1,9 @@
 package com.jjbacsa.jjbacsabackend.user.mapper;
 
+import com.jjbacsa.jjbacsabackend.etc.enums.FollowedType;
 import com.jjbacsa.jjbacsabackend.user.dto.UserRequest;
 import com.jjbacsa.jjbacsabackend.user.dto.UserResponse;
+import com.jjbacsa.jjbacsabackend.user.dto.UserResponseWithFollowedType;
 import com.jjbacsa.jjbacsabackend.user.entity.UserEntity;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -15,4 +17,7 @@ public interface UserMapper {
 
     @Mapping(target = "userCountResponse", source = "userCount")
     UserResponse toUserResponse(UserEntity userEntity);
+
+    @Mapping(target = "userCountResponse", source = "userEntity.userCount")
+    UserResponseWithFollowedType toUserResponse(UserEntity userEntity, FollowedType followedType);
 }

--- a/src/main/java/com/jjbacsa/jjbacsabackend/user/repository/querydsl/DslUserRepository.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/user/repository/querydsl/DslUserRepository.java
@@ -1,6 +1,8 @@
 package com.jjbacsa.jjbacsabackend.user.repository.querydsl;
 
+import com.jjbacsa.jjbacsabackend.etc.enums.FollowedType;
 import com.jjbacsa.jjbacsabackend.user.entity.UserEntity;
+import java.util.Map;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -8,6 +10,7 @@ import java.util.List;
 
 public interface DslUserRepository {
     Page<UserEntity> findAllByUserNameWithCursor(String keyword, Pageable pageable, Long cursor);
+    Map<Long, FollowedType> getFollowedTypesByUserAndUsers(UserEntity user, List<UserEntity> users);
     UserEntity findUserByIdWithCount(Long id);
     List<UserEntity> findAllUserByIdAndFollowWithCount(Long id);
 }

--- a/src/main/java/com/jjbacsa/jjbacsabackend/user/repository/querydsl/DslUserRepository.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/user/repository/querydsl/DslUserRepository.java
@@ -2,7 +2,9 @@ package com.jjbacsa.jjbacsabackend.user.repository.querydsl;
 
 import com.jjbacsa.jjbacsabackend.etc.enums.FollowedType;
 import com.jjbacsa.jjbacsabackend.user.entity.UserEntity;
+
 import java.util.Map;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -10,7 +12,10 @@ import java.util.List;
 
 public interface DslUserRepository {
     Page<UserEntity> findAllByUserNameWithCursor(String keyword, Pageable pageable, Long cursor);
+
     Map<Long, FollowedType> getFollowedTypesByUserAndUsers(UserEntity user, List<UserEntity> users);
+
     UserEntity findUserByIdWithCount(Long id);
+
     List<UserEntity> findAllUserByIdAndFollowWithCount(Long id);
 }

--- a/src/main/java/com/jjbacsa/jjbacsabackend/user/repository/querydsl/DslUserRepositoryImpl.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/user/repository/querydsl/DslUserRepositoryImpl.java
@@ -10,9 +10,11 @@ import com.jjbacsa.jjbacsabackend.user.entity.UserEntity;
 import com.querydsl.core.Tuple;
 import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.jpa.JPQLQuery;
+
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
@@ -68,11 +70,11 @@ public class DslUserRepositoryImpl extends QuerydslRepositorySupport implements 
         return tuple.get(0, Long.class);
     }
 
-    private FollowedType getFollowedType(Tuple tuple){
-        if(itemIsTure(tuple, 1)){
+    private FollowedType getFollowedType(Tuple tuple) {
+        if (itemIsTure(tuple, 1)) {
             return FollowedType.FOLLOWED;
         }
-        if(itemIsTure(tuple, 2)) {
+        if (itemIsTure(tuple, 2)) {
             return FollowedType.REQUESTED;
         }
         return FollowedType.NONE;

--- a/src/main/java/com/jjbacsa/jjbacsabackend/user/repository/querydsl/DslUserRepositoryImpl.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/user/repository/querydsl/DslUserRepositoryImpl.java
@@ -71,16 +71,16 @@ public class DslUserRepositoryImpl extends QuerydslRepositorySupport implements 
     }
 
     private FollowedType getFollowedType(Tuple tuple) {
-        if (itemIsTure(tuple, 1)) {
+        if (itemIsTrue(tuple, 1)) {
             return FollowedType.FOLLOWED;
         }
-        if (itemIsTure(tuple, 2)) {
+        if (itemIsTrue(tuple, 2)) {
             return FollowedType.REQUESTED;
         }
         return FollowedType.NONE;
     }
 
-    private boolean itemIsTure(Tuple tuple, int index) {
+    private boolean itemIsTrue(Tuple tuple, int index) {
         return Objects.equals(Boolean.TRUE, tuple.get(index, Boolean.class));
     }
 

--- a/src/main/java/com/jjbacsa/jjbacsabackend/user/repository/querydsl/DslUserRepositoryImpl.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/user/repository/querydsl/DslUserRepositoryImpl.java
@@ -1,12 +1,18 @@
 package com.jjbacsa.jjbacsabackend.user.repository.querydsl;
 
+import com.jjbacsa.jjbacsabackend.etc.enums.FollowedType;
 import com.jjbacsa.jjbacsabackend.follow.entity.QFollowEntity;
+import com.jjbacsa.jjbacsabackend.follow.entity.QFollowRequestEntity;
 import com.jjbacsa.jjbacsabackend.image.entity.QImageEntity;
 import com.jjbacsa.jjbacsabackend.user.entity.QUserCount;
 import com.jjbacsa.jjbacsabackend.user.entity.QUserEntity;
 import com.jjbacsa.jjbacsabackend.user.entity.UserEntity;
+import com.querydsl.core.Tuple;
 import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.jpa.JPQLQuery;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
@@ -17,6 +23,8 @@ import java.util.List;
 public class DslUserRepositoryImpl extends QuerydslRepositorySupport implements DslUserRepository {
     private static final QUserEntity qUser = QUserEntity.userEntity;
     private static final QImageEntity qImage = QImageEntity.imageEntity;
+    private static final QFollowEntity qFollow = QFollowEntity.followEntity;
+    private static final QFollowRequestEntity qFollowRequest = QFollowRequestEntity.followRequestEntity;
 
     public DslUserRepositoryImpl() {
         super(UserEntity.class);
@@ -42,6 +50,36 @@ public class DslUserRepositoryImpl extends QuerydslRepositorySupport implements 
                 .where(qUser.nickname.contains(keyword));
 
         return PageableExecutionUtils.getPage(users, pageable, countQuery::fetchCount);
+    }
+
+    @Override
+    public Map<Long, FollowedType> getFollowedTypesByUserAndUsers(UserEntity user, List<UserEntity> users) {
+        return from(qUser)
+                .select(qUser.id, qFollow.isNotNull(), qFollowRequest.isNotNull())
+                .leftJoin(qFollow).on(qUser.eq(qFollow.user), qFollow.follower.eq(user))
+                .leftJoin(qFollowRequest).on(qUser.eq(qFollowRequest.user), qFollowRequest.follower.eq(user))
+                .where(qUser.in(users))
+                .fetch()
+                .stream()
+                .collect(Collectors.toMap(this::getId, this::getFollowedType));
+    }
+
+    private Long getId(Tuple tuple) {
+        return tuple.get(0, Long.class);
+    }
+
+    private FollowedType getFollowedType(Tuple tuple){
+        if(itemIsTure(tuple, 1)){
+            return FollowedType.FOLLOWED;
+        }
+        if(itemIsTure(tuple, 2)) {
+            return FollowedType.REQUESTED;
+        }
+        return FollowedType.NONE;
+    }
+
+    private boolean itemIsTure(Tuple tuple, int index) {
+        return Objects.equals(Boolean.TRUE, tuple.get(index, Boolean.class));
     }
 
     @Override

--- a/src/main/java/com/jjbacsa/jjbacsabackend/user/repository/querydsl/DslUserRepositoryImpl.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/user/repository/querydsl/DslUserRepositoryImpl.java
@@ -58,8 +58,8 @@ public class DslUserRepositoryImpl extends QuerydslRepositorySupport implements 
     public Map<Long, FollowedType> getFollowedTypesByUserAndUsers(UserEntity user, List<UserEntity> users) {
         return from(qUser)
                 .select(qUser.id, qFollow.isNotNull(), qFollowRequest.isNotNull())
-                .leftJoin(qFollow).on(qUser.eq(qFollow.user), qFollow.follower.eq(user))
-                .leftJoin(qFollowRequest).on(qUser.eq(qFollowRequest.user), qFollowRequest.follower.eq(user))
+                .leftJoin(qFollow).on(qFollow.user.eq(user), qFollow.follower.eq(qUser))
+                .leftJoin(qFollowRequest).on(qFollowRequest.user.eq(user), qFollowRequest.follower.eq(qUser))
                 .where(qUser.in(users))
                 .fetch()
                 .stream()

--- a/src/main/java/com/jjbacsa/jjbacsabackend/user/service/UserService.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/user/service/UserService.java
@@ -4,6 +4,7 @@ import com.jjbacsa.jjbacsabackend.etc.dto.Token;
 import com.jjbacsa.jjbacsabackend.user.dto.EmailRequest;
 import com.jjbacsa.jjbacsabackend.user.dto.UserRequest;
 import com.jjbacsa.jjbacsabackend.user.dto.UserResponse;
+import com.jjbacsa.jjbacsabackend.user.dto.UserResponseWithFollowedType;
 import org.springframework.data.domain.Page;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -26,7 +27,7 @@ public interface UserService {
 
     UserResponse getLoginUser() throws Exception;
 
-    Page<UserResponse> searchUsers(String keyword, Integer pageSize, Long cursor) throws Exception;
+    Page<UserResponseWithFollowedType> searchUsers(String keyword, Integer pageSize, Long cursor) throws Exception;
 
     UserResponse getAccountInfo(Long id) throws Exception;
 

--- a/src/main/java/com/jjbacsa/jjbacsabackend/user/serviceImpl/UserServiceImpl.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/user/serviceImpl/UserServiceImpl.java
@@ -24,8 +24,9 @@ import com.jjbacsa.jjbacsabackend.util.AuthLinkUtil;
 import com.jjbacsa.jjbacsabackend.util.ImageUtil;
 import com.jjbacsa.jjbacsabackend.util.JwtUtil;
 import com.jjbacsa.jjbacsabackend.util.RedisUtil;
+
 import java.util.Map;
-import lombok.NonNull;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;

--- a/src/test/java/com/jjbacsa/jjbacsabackend/user/service/UserServiceTest.java
+++ b/src/test/java/com/jjbacsa/jjbacsabackend/user/service/UserServiceTest.java
@@ -6,6 +6,7 @@ import com.jjbacsa.jjbacsabackend.etc.enums.UserType;
 import com.jjbacsa.jjbacsabackend.etc.exception.RequestInputException;
 import com.jjbacsa.jjbacsabackend.user.dto.UserRequest;
 import com.jjbacsa.jjbacsabackend.user.dto.UserResponse;
+import com.jjbacsa.jjbacsabackend.user.dto.UserResponseWithFollowedType;
 import com.jjbacsa.jjbacsabackend.user.entity.CustomUserDetails;
 import com.jjbacsa.jjbacsabackend.user.entity.UserCount;
 import com.jjbacsa.jjbacsabackend.user.entity.UserEntity;
@@ -123,7 +124,7 @@ public class UserServiceTest {
     @DisplayName("유저 리스트 검색")
     @Test
     void searchUsers() throws Exception {
-        Page<UserResponse> result = userService
+        Page<UserResponseWithFollowedType> result = userService
                 .searchUsers("NoSearchName", 10, 0L);
         assertTrue(result.isEmpty());
 


### PR DESCRIPTION
`/users` 요청 시 현재 로그인한 유저와의 팔로우 관계 상태를 나타내는 상태값 추가
`NONE`, `REQUESTED`, `FOLLOWED`값으로 제공


- `querydsl` follow 관계 확인, follow request 관계 확인 -> tuple 반환, 0번 인덱스는 user의 id가 되고 인덱스가 select 된 컬럼
- 1번 컬럼이 존재할 시 follow 관계
- 2번 컬럼이 존재할 시 follow request 관계
