### PR TITLE
유저 검색 내 transaction 에러

### DIFF
--- a/src/main/java/com/jjbacsa/jjbacsabackend/user/controller/UserController.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/user/controller/UserController.java
@@ -74,7 +74,7 @@ public class UserController {
     @ApiOperation(
             value = "아이디 중복 확인",
             notes = "아이디 중복을 확인합니다." +
-            "\n\n\taccount : 유저 계정(1~20글자의 영문자 및 숫자)")
+                    "\n\n\taccount : 유저 계정(1~20글자의 영문자 및 숫자)")
     @ApiResponses({
             @ApiResponse(code = 200,
                     message = "OK",
@@ -153,6 +153,7 @@ public class UserController {
                     response = UserResponse.class,
                     responseContainer = "Page")
     })
+    @PreAuthorize("hasRole('NORMAL')")
     @GetMapping("/users")
     public ResponseEntity<Page<UserResponseWithFollowedType>> searchUsers(
             @Size(min = 1, max = 20, message = "닉네임은 1~20글자까지 검색할 수 있습니다.") @RequestParam String keyword,
@@ -230,8 +231,8 @@ public class UserController {
                     message = "OK")
     })
     @PostMapping("/user/email")
-    public ResponseEntity<String> sendAuthEmailCode (@Email(message = "이메일은 형식을 지켜야 합니다.")
-                                                     @RequestParam String email) throws Exception {
+    public ResponseEntity<String> sendAuthEmailCode(@Email(message = "이메일은 형식을 지켜야 합니다.")
+                                                    @RequestParam String email) throws Exception {
         userService.sendAuthEmailCode(email);
         return new ResponseEntity<>("OK", HttpStatus.OK);
     }
@@ -247,8 +248,8 @@ public class UserController {
                     message = "OK")
     })
     @PostMapping("/user/authenticate")
-    public ResponseEntity<String> sendAuthEmailLink (@Email(message = "이메일은 형식을 지켜야 합니다.")
-                                                 @RequestParam String email) throws Exception {
+    public ResponseEntity<String> sendAuthEmailLink(@Email(message = "이메일은 형식을 지켜야 합니다.")
+                                                    @RequestParam String email) throws Exception {
         userService.sendAuthEmailLink(email);
         return new ResponseEntity<>("OK", HttpStatus.OK);
     }
@@ -268,8 +269,8 @@ public class UserController {
     })
     @GetMapping("user/account")
     public ResponseEntity<UserResponse> findAccount(@Email(message = "이메일은 형식을 지켜야 합니다.")
-                                                  @RequestParam String email,
-                                              @RequestParam String code) throws Exception {
+                                                    @RequestParam String email,
+                                                    @RequestParam String code) throws Exception {
 
         return new ResponseEntity<>(userService.findAccount(email, code), HttpStatus.OK);
     }
@@ -292,7 +293,7 @@ public class UserController {
     })
     @PostMapping("user/password")
     public ResponseEntity<String> findPassword(@Validated(ValidationGroups.Update.class)
-                                                         @RequestBody EmailRequest request) throws Exception {
+                                               @RequestBody EmailRequest request) throws Exception {
         return new ResponseEntity<>(userService.findPassword(request), HttpStatus.OK);
     }
 
@@ -349,7 +350,7 @@ public class UserController {
     @PostMapping(value = "/login/{sns-type}")
     public ResponseEntity<Token> snsLogin(
             @PathVariable(name = "sns-type") OAuthType oAuthType
-            ) throws Exception {
+    ) throws Exception {
         return new ResponseEntity<>(oAuth2UserService.oAuthLoginByToken(oAuthType), HttpStatus.OK);
     }
 
@@ -368,8 +369,7 @@ public class UserController {
         HttpHeaders httpHeaders = new HttpHeaders();
         try {
             httpHeaders.setLocation(userService.authEmail(accessToken, refreshToken));
-        }
-        catch (RequestInputException exception) {
+        } catch (RequestInputException exception) {
             httpHeaders.setLocation(URI.create("../email-error"));
         }
 
@@ -399,7 +399,7 @@ public class UserController {
     @PatchMapping("/user/nickname")
     public ResponseEntity<UserResponse> modifyNickname(@Pattern(regexp = "^[a-zA-z가-힣0-9]{1,20}$",
             groups = {ValidationGroups.Update.class}, message = "닉네임에 특수문자와 초성은 불가능합니다.")
-                                                           @RequestParam String nickname) throws Exception {
+                                                       @RequestParam String nickname) throws Exception {
         return new ResponseEntity<>(userService.modifyNickname(nickname), HttpStatus.OK);
     }
 

--- a/src/main/java/com/jjbacsa/jjbacsabackend/user/serviceImpl/InternalUserServiceImpl.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/user/serviceImpl/InternalUserServiceImpl.java
@@ -35,11 +35,16 @@ public class InternalUserServiceImpl implements InternalUserService {
     @Override
     public UserEntity getLoginUser() throws Exception {
 
-        Long userId = ((CustomUserDetails) SecurityContextHolder
+        Object principal = SecurityContextHolder
                 .getContext()
                 .getAuthentication()
-                .getPrincipal())
-                .getId();
+                .getPrincipal();
+
+        if (principal == null || principal.toString().equals("anonymousUser")) {
+            throw new RequestInputException(ErrorMessage.INVALID_TOKEN);
+        }
+
+        Long userId = ((CustomUserDetails) principal).getId();
 
         return getUserById(userId);
     }

--- a/src/main/java/com/jjbacsa/jjbacsabackend/user/serviceImpl/UserServiceImpl.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/user/serviceImpl/UserServiceImpl.java
@@ -24,9 +24,6 @@ import com.jjbacsa.jjbacsabackend.util.AuthLinkUtil;
 import com.jjbacsa.jjbacsabackend.util.ImageUtil;
 import com.jjbacsa.jjbacsabackend.util.JwtUtil;
 import com.jjbacsa.jjbacsabackend.util.RedisUtil;
-
-import java.util.Map;
-
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -40,6 +37,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import javax.servlet.http.HttpServletRequest;
 import java.net.URI;
+import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 
@@ -175,14 +173,9 @@ public class UserServiceImpl implements UserService {
 
         Page<UserEntity> result = userRepository.findAllByUserNameWithCursor(keyword, pageable, cursor);
 
-        try {
-            UserEntity loginUser = userService.getLoginUser();
-            Map<Long, FollowedType> followedTypes = userRepository.getFollowedTypesByUserAndUsers(loginUser, result.getContent());
-            return result.map(user -> UserMapper.INSTANCE.toUserResponse(user, followedTypes.get(user.getId())));
-        } catch (Exception ignore) {
-        }
-
-        return result.map(user -> UserMapper.INSTANCE.toUserResponse(user, FollowedType.NONE));
+        UserEntity loginUser = userService.getLoginUser();
+        Map<Long, FollowedType> followedTypes = userRepository.getFollowedTypesByUserAndUsers(loginUser, result.getContent());
+        return result.map(user -> UserMapper.INSTANCE.toUserResponse(user, followedTypes.getOrDefault(user.getId(), FollowedType.NONE)));
     }
 
     @Override


### PR DESCRIPTION
유저 검색 내에서 try catch 사용으로 이미 roll-back 지정된 transaction이 재사용되면서 발생한 문제 해결입니다. 아래와 같은 내역이 진행되었습니다.

- user search api 내 try catch 제거
- internal user service의 get login user 사용 시 익명 유저(context 내 유저가 없는 경우) 검사 추가
- user search 사용 시 method security 추가

메소드 시큐리티의 경우 현재 피그마 확인 후 로그인 -> 친구 검색 순으로 진행됨을 보고 진행했습니다. 차후 수정 및 문제 사항 발생 시 수정하겠습니다.