### PR TITLE
multipart/form-data 바인딩 에러 수정

### DIFF
--- a/src/main/java/com/jjbacsa/jjbacsabackend/etc/config/GlobalExceptionHandler.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/etc/config/GlobalExceptionHandler.java
@@ -124,7 +124,7 @@ public class GlobalExceptionHandler {
         int errorLine = e.getStackTrace()[0].getLineNumber();
 
         String requestParam = new ObjectMapper().writeValueAsString(ParserUtil.splitQueryString(request.getQueryString()));
-        String requestBody = request.getReader().lines().collect(Collectors.joining(System.lineSeparator()));
+        String requestBody = (String) request.getAttribute("requestBody");
         String message = String.format("```%s %s Line %d```\n```===== [Message] ===== \n%s\n\n===== [Controller] =====\n%s\n\n===== [RequestParameter] =====\n%s\n\n===== [RequestBody] =====\n%s```",
                 errorName, errorFile, errorLine, errorMessage, handlerMethod, requestParam, requestBody);
 

--- a/src/main/java/com/jjbacsa/jjbacsabackend/etc/config/RepeatableRequestWrapper.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/etc/config/RepeatableRequestWrapper.java
@@ -1,30 +1,45 @@
 package com.jjbacsa.jjbacsabackend.etc.config;
 
-import com.amazonaws.util.IOUtils;
 import com.nimbusds.oauth2.sdk.util.StringUtils;
+import org.apache.commons.io.IOUtils;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 
 import javax.servlet.ReadListener;
+import javax.servlet.ServletException;
 import javax.servlet.ServletInputStream;
 import javax.servlet.ServletRequest;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletRequestWrapper;
+import javax.servlet.http.Part;
 import java.io.*;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.Collections;
 
 public class RepeatableRequestWrapper extends HttpServletRequestWrapper {
 
     private final Charset encoding;
-    private byte[] rawData;
+    private final byte[] rawData;
+    private Collection<Part> parts;
 
-    public RepeatableRequestWrapper(HttpServletRequest request) throws IOException {
+    public RepeatableRequestWrapper(HttpServletRequest request) throws IOException, ServletException {
         super(request);
-
         String characterEncoding = request.getCharacterEncoding();
         if (StringUtils.isBlank(characterEncoding)) {
             characterEncoding = StandardCharsets.UTF_8.name();
         }
         this.encoding = Charset.forName(characterEncoding);
+
+        // Store the parts to the instance variable
+        try {
+            if (super.getHeader(HttpHeaders.CONTENT_TYPE).startsWith(MediaType.MULTIPART_FORM_DATA_VALUE)) {
+                this.parts = request.getParts();
+            }
+        } catch (IllegalStateException e) { // multipart/form-data가 아닌 경우
+            this.parts = Collections.emptyList();
+        }
 
         // Convert InputStream data to byte array and store it to this wrapper instance.
         try {
@@ -33,6 +48,10 @@ public class RepeatableRequestWrapper extends HttpServletRequestWrapper {
         } catch (IOException e) {
             throw e;
         }
+
+        // Store request body to the request attribute.
+        String requestBody = new String(this.rawData, this.encoding);
+        request.setAttribute("requestBody", requestBody);
     }
 
     @Override
@@ -66,6 +85,16 @@ public class RepeatableRequestWrapper extends HttpServletRequestWrapper {
     @Override
     public BufferedReader getReader() throws IOException {
         return new BufferedReader(new InputStreamReader(this.getInputStream(), this.encoding));
+    }
+
+    @Override
+    public Collection<Part> getParts() throws IOException, ServletException {
+        return this.parts;
+    }
+
+    @Override
+    public Part getPart(String name) throws IOException, ServletException {
+        return super.getPart(name);
     }
 
     @Override


### PR DESCRIPTION
슬랙 노티를 보내기 위해  `RepeatableRequestWrapper`에서 `requestBody`를 byte array로 복사하여 저장한 후, 해당 byte array를 여러 번 읽어들이면 `Multipart/form-data` 데이터의 변환에 문제가 발생하여 데이터가 바인딩되지 않고 `null`값이 들어감 
`multipart/form-data`는 `Part` 클래스로 저장하여 변환에 문제가 없도록 수정

- multipart/form-data 요청 시 byte array로 복사하기 전 Part 클래스에 담아 변환하도록 수정
- RequestBody의 내용을 `context`에 담아 저장하고, 슬랙 노티 발생 시 request attribute에서 읽어오도록 수정