### PR TITLE
탈퇴 사유 저장 추가

### DIFF
--- a/src/main/java/com/jjbacsa/jjbacsabackend/user/controller/UserController.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/user/controller/UserController.java
@@ -8,6 +8,7 @@ import com.jjbacsa.jjbacsabackend.user.dto.EmailRequest;
 import com.jjbacsa.jjbacsabackend.user.dto.UserRequest;
 import com.jjbacsa.jjbacsabackend.user.dto.UserResponse;
 import com.jjbacsa.jjbacsabackend.user.dto.UserResponseWithFollowedType;
+import com.jjbacsa.jjbacsabackend.user.dto.WithdrawRequest;
 import com.jjbacsa.jjbacsabackend.user.service.InternalEmailService;
 import com.jjbacsa.jjbacsabackend.user.service.UserService;
 import com.jjbacsa.jjbacsabackend.user.serviceImpl.OAuth2UserServiceImpl;
@@ -215,8 +216,8 @@ public class UserController {
     })
     @PreAuthorize(("hasRole('NORMAL')"))
     @DeleteMapping("/user/me")
-    public ResponseEntity<Void> withdraw() throws Exception {
-        userService.withdraw();
+    public ResponseEntity<Void> withdraw(@RequestBody WithdrawRequest request) throws Exception {
+        userService.withdraw(request);
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 

--- a/src/main/java/com/jjbacsa/jjbacsabackend/user/controller/UserController.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/user/controller/UserController.java
@@ -207,8 +207,13 @@ public class UserController {
             value = "회원 탈퇴",
             notes = "회원 탈퇴\n\n" +
                     "필요 헤더\n\n" +
-                    "\tAuthorization : Bearer + access token"
-    )
+                    "\tAuthorization : Bearer + access token" +
+                    "필요한 필드\n\n" +
+                    "\t{\n\n     " +
+                    "reason : 변경 사유,\n\n     " +
+                    "discomfort : 개선 사항\n\n    " +
+                    "}\t",
+            authorizations = @Authorization(value = "Bearer + refreshToken"))
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @ApiResponses({
             @ApiResponse(code = 204,

--- a/src/main/java/com/jjbacsa/jjbacsabackend/user/controller/UserController.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/user/controller/UserController.java
@@ -8,6 +8,7 @@ import com.jjbacsa.jjbacsabackend.user.dto.EmailRequest;
 import com.jjbacsa.jjbacsabackend.user.dto.UserRequest;
 import com.jjbacsa.jjbacsabackend.user.dto.UserResponse;
 import com.jjbacsa.jjbacsabackend.user.dto.UserResponseWithFollowedType;
+import com.jjbacsa.jjbacsabackend.user.dto.WithdrawReasonResponse;
 import com.jjbacsa.jjbacsabackend.user.dto.WithdrawRequest;
 import com.jjbacsa.jjbacsabackend.user.service.InternalEmailService;
 import com.jjbacsa.jjbacsabackend.user.service.UserService;
@@ -207,12 +208,7 @@ public class UserController {
             value = "회원 탈퇴",
             notes = "회원 탈퇴\n\n" +
                     "필요 헤더\n\n" +
-                    "\tAuthorization : Bearer + access token" +
-                    "필요한 필드\n\n" +
-                    "\t{\n\n     " +
-                    "reason : 변경 사유,\n\n     " +
-                    "discomfort : 개선 사항\n\n    " +
-                    "}\t",
+                    "\tAuthorization : Bearer + access token",
             authorizations = @Authorization(value = "Bearer + refreshToken"))
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @ApiResponses({
@@ -221,9 +217,33 @@ public class UserController {
     })
     @PreAuthorize(("hasRole('NORMAL')"))
     @DeleteMapping("/user/me")
-    public ResponseEntity<Void> withdraw(@RequestBody WithdrawRequest request) throws Exception {
-        userService.withdraw(request);
+    public ResponseEntity<Void> withdraw() throws Exception {
+        userService.withdraw();
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+
+    @ApiOperation(
+            value = "탈퇴 사유 저장",
+            notes = "탈퇴 사유 저장\n\n" +
+                    "필요 헤더\n\n" +
+                    "\tAuthorization : Bearer + access token" +
+                    "\n\n필요한 필드\n\n" +
+                    "\t{\n\n     " +
+                    "reason : 변경 사유,\n\n     " +
+                    "discomfort : 개선 사항\n\n    " +
+                    "}\t\n\n" +
+                    "탈퇴가 먼저 이뤄지면 탈퇴 사유를 저장할 유저를 찾지 못합니다.\n\n" +
+                    "탈퇴 이전에 먼저 탈퇴 사유를 저장해주시길 바랍니다.",
+            authorizations = @Authorization(value = "Bearer + refreshToken"))
+    @ResponseStatus(HttpStatus.CREATED)
+    @ApiResponses({
+            @ApiResponse(code = 201,
+                    message = "생성된 탈퇴 사유")
+    })
+    @PreAuthorize(("hasRole('NORMAL')"))
+    @PostMapping("/user/withdraw-reason")
+    public ResponseEntity<WithdrawReasonResponse> createWithdrawReason(@RequestBody WithdrawRequest request) throws Exception {
+        return new ResponseEntity<WithdrawReasonResponse>(userService.createWithdrawReason(request), HttpStatus.CREATED);
     }
 
     @ApiOperation(
@@ -360,7 +380,7 @@ public class UserController {
     @PreAuthorize("hasRole('NORMAL')")
     @PatchMapping(value = "/user/profile")
     public ResponseEntity<UserResponse> modifyProfile(@RequestPart(value = "profile", required = false)
-                                                      MultipartFile profile) throws Exception {
+                                                              MultipartFile profile) throws Exception {
         return new ResponseEntity<>(userService.modifyProfile(profile), HttpStatus.OK);
     }
 

--- a/src/main/java/com/jjbacsa/jjbacsabackend/user/dto/WithdrawReasonResponse.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/user/dto/WithdrawReasonResponse.java
@@ -1,0 +1,29 @@
+package com.jjbacsa.jjbacsabackend.user.dto;
+
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class WithdrawReasonResponse {
+
+    @ApiModelProperty(notes = "탈퇴 대상 id", example = "1")
+    private Long id;
+
+    @ApiModelProperty(notes = "저장된 탈퇴 사유", example = "string")
+    private String reason;
+
+    @ApiModelProperty(notes = "저장된 개선 바라는 점", example = "string")
+    private String discomfort;
+
+    public WithdrawReasonResponse(Long id, WithdrawRequest request) {
+        this.id = id;
+        this.reason = request.getReason();
+        this.discomfort = request.getDiscomfort();
+    }
+}

--- a/src/main/java/com/jjbacsa/jjbacsabackend/user/dto/WithdrawRequest.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/user/dto/WithdrawRequest.java
@@ -1,0 +1,19 @@
+package com.jjbacsa.jjbacsabackend.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class WithdrawRequest {
+
+    private String reason;
+
+    private String discomfort;
+}

--- a/src/main/java/com/jjbacsa/jjbacsabackend/user/entity/WithdrawReasonEntity.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/user/entity/WithdrawReasonEntity.java
@@ -1,0 +1,41 @@
+package com.jjbacsa.jjbacsabackend.user.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import javax.persistence.Basic;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.MapsId;
+import javax.persistence.OneToOne;
+import javax.persistence.Table;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "withdraw_reason")
+public class WithdrawReasonEntity {
+
+    @Id
+    @Column(name = "user_id")
+    private Long userId;
+
+    @MapsId
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private UserEntity user;
+
+    @Basic
+    @Column(name = "reason")
+    private String reason;
+
+    @Basic
+    @Column(name = "discomfort")
+    private String discomfort;
+}

--- a/src/main/java/com/jjbacsa/jjbacsabackend/user/repository/WithdrawReasonRepository.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/user/repository/WithdrawReasonRepository.java
@@ -1,0 +1,9 @@
+package com.jjbacsa.jjbacsabackend.user.repository;
+
+import com.jjbacsa.jjbacsabackend.user.entity.WithdrawReasonEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface WithdrawReasonRepository extends JpaRepository<WithdrawReasonEntity, Long> {
+}

--- a/src/main/java/com/jjbacsa/jjbacsabackend/user/service/UserService.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/user/service/UserService.java
@@ -5,6 +5,7 @@ import com.jjbacsa.jjbacsabackend.user.dto.EmailRequest;
 import com.jjbacsa.jjbacsabackend.user.dto.UserRequest;
 import com.jjbacsa.jjbacsabackend.user.dto.UserResponse;
 import com.jjbacsa.jjbacsabackend.user.dto.UserResponseWithFollowedType;
+import com.jjbacsa.jjbacsabackend.user.dto.WithdrawRequest;
 import org.springframework.data.domain.Page;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -33,7 +34,7 @@ public interface UserService {
 
     UserResponse modifyUser(UserRequest request) throws Exception;
 
-    void withdraw() throws Exception;
+    void withdraw(WithdrawRequest request) throws Exception;
 
     UserResponse modifyProfile(MultipartFile profile) throws Exception;
 

--- a/src/main/java/com/jjbacsa/jjbacsabackend/user/service/UserService.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/user/service/UserService.java
@@ -5,7 +5,9 @@ import com.jjbacsa.jjbacsabackend.user.dto.EmailRequest;
 import com.jjbacsa.jjbacsabackend.user.dto.UserRequest;
 import com.jjbacsa.jjbacsabackend.user.dto.UserResponse;
 import com.jjbacsa.jjbacsabackend.user.dto.UserResponseWithFollowedType;
+import com.jjbacsa.jjbacsabackend.user.dto.WithdrawReasonResponse;
 import com.jjbacsa.jjbacsabackend.user.dto.WithdrawRequest;
+import com.jjbacsa.jjbacsabackend.user.entity.UserEntity;
 import org.springframework.data.domain.Page;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -34,7 +36,9 @@ public interface UserService {
 
     UserResponse modifyUser(UserRequest request) throws Exception;
 
-    void withdraw(WithdrawRequest request) throws Exception;
+    void withdraw() throws Exception;
+
+    WithdrawReasonResponse createWithdrawReason(WithdrawRequest request) throws Exception;
 
     UserResponse modifyProfile(MultipartFile profile) throws Exception;
 

--- a/src/main/java/com/jjbacsa/jjbacsabackend/user/serviceImpl/UserServiceImpl.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/user/serviceImpl/UserServiceImpl.java
@@ -217,8 +217,7 @@ public class UserServiceImpl implements UserService {
         userCountRepository.updateAllFriendsCountByUser(user);
         followService.deleteFollowWithUser(user);
 
-        userRepository.delete(user);
-//        user.setIsDeleted(1);
+        user.setIsDeleted(1);
 
         //회원 탈퇴에 따른 리프레시 토큰 삭제
         String existToken = redisUtil.getStringValue(String.valueOf(user.getId()));

--- a/src/main/resources/db/migration/V11__create_withdraw_reason_table.sql
+++ b/src/main/resources/db/migration/V11__create_withdraw_reason_table.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS withdraw_reason
+(
+    user_id          BIGINT       PRIMARY KEY,
+    reason           VARCHAR(30)  NOT NULL,
+    discomfort       VARCHAR(255) NOT NULL,
+    FOREIGN KEY (user_id) REFERENCES user (id) ON DELETE CASCADE
+) default character set utf8mb4
+collate utf8mb4_bin;

--- a/src/test/java/com/jjbacsa/jjbacsabackend/user/service/UserServiceTest.java
+++ b/src/test/java/com/jjbacsa/jjbacsabackend/user/service/UserServiceTest.java
@@ -152,11 +152,7 @@ public class UserServiceTest {
     @DisplayName("회원 탈퇴")
     @Test
     void withdraw() throws Exception {
-        WithdrawRequest request = new WithdrawRequest();
-        request.setReason("테스트 이유");
-        request.setDiscomfort("테스트 개선사항");
-
-        userService.withdraw(request);
+        userService.withdraw();
         assertThrows(RequestInputException.class,
                 () -> userService.getAccountInfo(userService.getLoginUser().getId()));
 

--- a/src/test/java/com/jjbacsa/jjbacsabackend/user/service/UserServiceTest.java
+++ b/src/test/java/com/jjbacsa/jjbacsabackend/user/service/UserServiceTest.java
@@ -7,6 +7,7 @@ import com.jjbacsa.jjbacsabackend.etc.exception.RequestInputException;
 import com.jjbacsa.jjbacsabackend.user.dto.UserRequest;
 import com.jjbacsa.jjbacsabackend.user.dto.UserResponse;
 import com.jjbacsa.jjbacsabackend.user.dto.UserResponseWithFollowedType;
+import com.jjbacsa.jjbacsabackend.user.dto.WithdrawRequest;
 import com.jjbacsa.jjbacsabackend.user.entity.CustomUserDetails;
 import com.jjbacsa.jjbacsabackend.user.entity.UserCount;
 import com.jjbacsa.jjbacsabackend.user.entity.UserEntity;
@@ -151,7 +152,11 @@ public class UserServiceTest {
     @DisplayName("회원 탈퇴")
     @Test
     void withdraw() throws Exception {
-        userService.withdraw();
+        WithdrawRequest request = new WithdrawRequest();
+        request.setReason("테스트 이유");
+        request.setDiscomfort("테스트 개선사항");
+
+        userService.withdraw(request);
         assertThrows(RequestInputException.class,
                 () -> userService.getAccountInfo(userService.getLoginUser().getId()));
 


### PR DESCRIPTION
### 작업 내용
- 회원 탈퇴 api 탈퇴 사유 저장 로직 추가
- 탈퇴 사유 테이블 추가
- 탈퇴 사유 엔티티 추가

### 특이사항
회원 탈퇴와 탈퇴 사유 저장은 한 트랜잭션으로 묶으려다보니 다음 문제가 있습니다.
문제에 대해서 피드백 및 의견 부탁드립니다.

1. HTTP Method delete에 Body 요청 포함
2. 탈퇴와 탈퇴 사유가 한 API에 묶임