### PR TITLE
docs: issue template 도입

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -1,0 +1,13 @@
+---
+name: Bug Report
+about: A feature with a list of APIs
+title: ''
+labels: "bug"
+assignees: ''
+---
+
+## Description
+<!-- 설명 -->
+
+## Remark
+<!-- 특이사항 -->

--- a/.github/ISSUE_TEMPLATE/FEATURE.md
+++ b/.github/ISSUE_TEMPLATE/FEATURE.md
@@ -1,0 +1,18 @@
+---
+name: Feature
+about: A feature with a list of APIs
+title: ''
+labels: "enhancement" 
+assignees: ''
+---
+
+## Description
+<!-- 설명 -->
+
+## Task List
+<!-- 각각의 API 업무 -->
+
+- [ ] Task1
+
+## Remark
+<!-- 특이사항 -->

--- a/.github/ISSUE_TEMPLATE/TASK.md
+++ b/.github/ISSUE_TEMPLATE/TASK.md
@@ -1,0 +1,17 @@
+---
+name: Task
+about: A Task For API
+title: ''
+labels: "task"
+assignees: ''
+---
+
+## Description
+<!-- 설명 -->
+
+## Progress
+<!-- 진행 내역 -->
+- [ ] 
+
+## Remark
+<!-- 특이사항 -->


### PR DESCRIPTION
## 설명
이슈에 활용할 템플릿 도입.

## 예시 이미지
![image](https://github.com/BCSDLab/JJBAKSA_BACK_END/assets/71889359/609960fd-8b13-4c55-b0fa-f3d92a05c120)

## 특이사항
- 좌측 하단 Blank tempalte을 선택할 수도 있음.
- 참고: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository