### PR TITLE
단일 상점 조회 시 Response에 shopId 추가

### DIFF
--- a/src/main/java/com/jjbacsa/jjbacsabackend/google/dto/response/ShopResponse.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/google/dto/response/ShopResponse.java
@@ -1,15 +1,17 @@
 package com.jjbacsa.jjbacsabackend.google.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Builder;
 import lombok.Getter;
 
 /**
  * shopDto(단일 상점 자세한 정보) 반환되는 클래스
  */
-
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @Builder
 @Getter
 public class ShopResponse {
+    private Long shopId;
     private String placeId;
     private String name;
     private String formattedAddress;
@@ -32,5 +34,9 @@ public class ShopResponse {
 
     public void setIsScrap(boolean isScrap) {
         this.isScrap = isScrap;
+    }
+
+    public void setShopId(Long shopId) {
+        this.shopId = shopId;
     }
 }

--- a/src/main/java/com/jjbacsa/jjbacsabackend/google/serviceImpl/GoogleShopServiceImpl.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/google/serviceImpl/GoogleShopServiceImpl.java
@@ -171,7 +171,7 @@ public class GoogleShopServiceImpl implements GoogleShopService {
         if (shop.isPresent()) {
             GoogleShopCount shopCount = shop.get().getShopCount();
             shopResponse.setShopCount(shopCount.getTotalRating(), shopCount.getRatingCount());
-
+            shopResponse.setShopId(shop.get().getId());
             isScrap = scrapService.isUserScrapShop(shop.get());
         }
 


### PR DESCRIPTION
Review Cursor Paging을 구현하는 중

리뷰가 작성된 상점 리스트를 반환해야하는 부분이 있음 placeId를 기준으로 페이징하려 했으나 한계점이 있어 수정하게 됨
피그마 010_03 참고
![image](https://github.com/BCSDLab/JJBAKSA_BACK_END/assets/84260096/2391b21a-7b38-4a21-ae50-3ab7a191b7fb)

Cursor를 placeId로 구현할 수 없는 이유

1. placeId의 생성 기준이 명확치 않음
2. `장소 ID는 장소를 고유하게 나타내는 텍스트 식별자입니다. 식별자의 길이는 서로 다를 수 있습니다(장소 ID에는 길이 제한이 없음)` [구글 문서](https://developers.google.com/maps/documentation/places/web-service/place-id?hl=ko)

이에 따라 **placeId를 비교하여** 페이징해올 수 없어 shopId를 기준으로 페이징 해야할 것 같아 shopId를 추가하였습니다.
shopId 추가에 따른 수정 사항이 생기는 지 확인 부탁드립니다.!