### PR TITLE
회원 탈퇴 후 일주일 이내 아이디 중복 검사

### DIFF
--- a/src/main/java/com/jjbacsa/jjbacsabackend/user/repository/UserRepository.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/user/repository/UserRepository.java
@@ -22,7 +22,12 @@ public interface UserRepository extends JpaRepository<UserEntity, Long>, DslUser
 
     Optional<UserEntity> findByEmailAndPasswordIsNotNull(String email);
 
-    boolean existsByAccount(String account);
+    @Query(value =
+            "select exists (select * from user u where u.account = :account " +
+            "and (u.is_deleted = 0 " +
+            "   or (u.is_deleted = 1 and u.updated_at > DATE_ADD(NOW(), INTERVAL - 7 DAY))))",
+            nativeQuery = true)
+    Integer existsByAccount(@Param("account") String account);
 
     boolean existsByEmailAndPasswordIsNotNull(String email);
 

--- a/src/main/java/com/jjbacsa/jjbacsabackend/user/repository/UserRepository.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/user/repository/UserRepository.java
@@ -25,7 +25,7 @@ public interface UserRepository extends JpaRepository<UserEntity, Long>, DslUser
     @Query(value =
             "select exists (select * from user u where u.account = :account " +
             "and (u.is_deleted = 0 " +
-            "   or (u.is_deleted = 1 and u.updated_at > DATE_ADD(NOW(), INTERVAL - 7 DAY))))",
+            "   or (u.is_deleted = 1 and u.updated_at > DATE_ADD(NOW(), INTERVAL - 1 DAY))))",
             nativeQuery = true)
     Integer existsByAccount(@Param("account") String account);
 

--- a/src/main/java/com/jjbacsa/jjbacsabackend/user/serviceImpl/UserServiceImpl.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/user/serviceImpl/UserServiceImpl.java
@@ -316,7 +316,7 @@ public class UserServiceImpl implements UserService {
     }
 
     private void validateExistAccount(String account) {
-        if (userRepository.existsByAccount(account)) {
+        if (userRepository.existsByAccount(account) > 0) {
             throw new RequestInputException(ErrorMessage.ALREADY_EXISTS_ACCOUNT);
         }
     }

--- a/src/test/java/com/jjbacsa/jjbacsabackend/user/repository/UserRepositoryTest.java
+++ b/src/test/java/com/jjbacsa/jjbacsabackend/user/repository/UserRepositoryTest.java
@@ -49,7 +49,7 @@ class UserRepositoryTest {
 
         userRepository.save(user);
 
-        assertTrue(userRepository.existsByAccount(user.getAccount()));
-        assertFalse(userRepository.existsByAccount("testuser2"));
+        assertEquals(userRepository.existsByAccount(user.getAccount()), 1);
+        assertEquals(userRepository.existsByAccount("testuser2"), 0);
     }
 }


### PR DESCRIPTION
### 탈퇴 후 24시간 이내 중복 검사 로직 추가

- 회원 탈퇴 후 24시간 이내 유저도 아이디 중복 검사 조건에 포함
- @Where Annotation이 Entity에 적용되어 있어 Native Query로 진행