### PR TITLE
전체 문의, 나의 문의 조회 기능 추가

### DIFF
--- a/src/main/java/com/jjbacsa/jjbacsabackend/inquiry/controller/InquiryController.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/inquiry/controller/InquiryController.java
@@ -2,11 +2,13 @@ package com.jjbacsa.jjbacsabackend.inquiry.controller;
 
 import com.jjbacsa.jjbacsabackend.etc.annotations.ValidationGroups;
 import com.jjbacsa.jjbacsabackend.inquiry.dto.request.AnswerRequest;
+import com.jjbacsa.jjbacsabackend.inquiry.dto.request.InquiryCursorRequest;
 import com.jjbacsa.jjbacsabackend.inquiry.dto.request.InquiryRequest;
 import com.jjbacsa.jjbacsabackend.inquiry.dto.response.InquiryResponse;
 import com.jjbacsa.jjbacsabackend.inquiry.service.InquiryService;
 import io.swagger.annotations.*;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -40,7 +42,7 @@ public class InquiryController {
 
     @ApiOperation(
             value = "Inquiry 작성",
-            notes = "Inquiry를 작성합니다.\n\n" +
+            notes = "Inquiry를 작성합니다. MediaType은 MULTIPART_FORM_DATA_VALUE를 선택해주세요.\n\n" +
                     "{\n\n" +
                     "       \"title\" : \"제목\"\n\n" +
                     "       \"content\" : \"내용\"\n\n" +
@@ -60,7 +62,7 @@ public class InquiryController {
 
     @ApiOperation(
             value = "Inquiry 수정",
-            notes = "Inquiry를 수정합니다.\n\n" +
+            notes = "Inquiry를 수정합니다. MediaType은 MULTIPART_FORM_DATA_VALUE를 선택해주세요.\n\n" +
                     "{\n\n" +
                     "       \"inquiryId\" : \"수정할 Inquiry의 id\"\"\n\n" +
                     "       \"title\" : \"제목\"\n\n" +
@@ -113,4 +115,87 @@ public class InquiryController {
     public ResponseEntity<InquiryResponse> answer(@Validated(ValidationGroups.Create.class) @RequestBody AnswerRequest answerRequest, @ApiParam("답변할 Inquiry Id") @PathVariable("inquiry-id") Long inquiryId) {
         return new ResponseEntity<>(inquiryService.addAnswer(answerRequest, inquiryId), HttpStatus.OK);
     }
+
+    @ApiOperation(
+            value = "전체 Inquiry 조회",
+            notes = "전체 Inquiry를 조회합니다.\n\n" +
+                    "커서 기반 페이징\n\n" +
+                    "example : \n\n" +
+                    "{\n\n" +
+                    "       \"idCursor\" : \"조회한 마지막 Inquiry id, 첫 조회는 null\"\n\n" +
+                    "       \"dateCursor\" : \"조회한 마지막 리뷰 createdAt, 첫 조회는 null\"\n\n" +
+                    "       \"size\" : \"조회할 Inquiry의 개수\"\n\n" +
+                    "}", authorizations = @Authorization(value = "Bearer +accessToken"))
+    @ApiResponses({
+            @ApiResponse(code = 200,
+                    message = "조회한 Inquiry 정보",
+                    response = InquiryResponse.class)
+    })
+    @GetMapping(value = "/inquiry")
+    public ResponseEntity<Page<InquiryResponse>> getInquiries(@Validated InquiryCursorRequest inquiryCursorRequest) {
+        return new ResponseEntity<>(inquiryService.getInquiries(inquiryCursorRequest), HttpStatus.OK);
+    }
+
+    @ApiOperation(
+            value = "나의 Inquiry 조회",
+            notes = "나의 Inquiry를 조회합니다.\n\n" +
+                    "커서 기반 페이징\n\n" +
+                    "example : \n\n" +
+                    "{\n\n" +
+                    "       \"idCursor\" : \"조회한 마지막 Inquiry id, 첫 조회는 null\"\n\n" +
+                    "       \"dateCursor\" : \"조회한 마지막 리뷰 createdAt, 첫 조회는 null\"\n\n" +
+                    "       \"size\" : \"조회할 Inquiry의 개수\"\n\n" +
+                    "}", authorizations = @Authorization(value = "Bearer +accessToken"))
+    @ApiResponses({
+            @ApiResponse(code = 200,
+                    message = "조회한 Inquiry 정보",
+                    response = InquiryResponse.class)
+    })
+    @GetMapping(value = "/inquiry/me")
+    public ResponseEntity<Page<InquiryResponse>> getMyInquiries(@Validated InquiryCursorRequest inquiryCursorRequest) throws Exception {
+        return new ResponseEntity<>(inquiryService.getMyInquiries(inquiryCursorRequest), HttpStatus.OK);
+    }
+
+    @ApiOperation(
+            value = "Inquiry 검색",
+            notes = "Inquiry를 검색 합니다.\n\n" +
+                    "커서 기반 페이징\n\n" +
+                    "example : \n\n" +
+                    "{\n\n" +
+                    "       \"idCursor\" : \"조회한 마지막 Inquiry id, 첫 조회는 null\"\n\n" +
+                    "       \"dateCursor\" : \"조회한 마지막 리뷰 createdAt, 첫 조회는 null\"\n\n" +
+                    "       \"size\" : \"조회할 Inquiry의 개수\"\n\n" +
+                    "       \"searchWord\" : \"검색어\"\n\n" +
+                    "}", authorizations = @Authorization(value = "Bearer +accessToken"))
+    @ApiResponses({
+            @ApiResponse(code = 200,
+                    message = "조회한 Inquiry 정보",
+                    response = InquiryResponse.class)
+    })
+    @GetMapping(value = "/inquiry/search/{search-word}")
+    public ResponseEntity<Page<InquiryResponse>> searchInquiries(@Validated InquiryCursorRequest inquiryCursorRequest, @ApiParam("검색어") @PathVariable(name = "search-word") String searchWord) {
+        return new ResponseEntity<>(inquiryService.searchInquiries(inquiryCursorRequest, searchWord), HttpStatus.OK);
+    }
+
+    @ApiOperation(
+            value = "나의 Inquiry 검색",
+            notes = "나의 Inquiry를 검색합니다.\n\n" +
+                    "커서 기반 페이징\n\n" +
+                    "example : \n\n" +
+                    "{\n\n" +
+                    "       \"idCursor\" : \"조회한 마지막 Inquiry id, 첫 조회는 null\"\n\n" +
+                    "       \"dateCursor\" : \"조회한 마지막 리뷰 createdAt, 첫 조회는 null\"\n\n" +
+                    "       \"size\" : \"조회할 Inquiry의 개수\"\n\n" +
+                    "       \"searchWord\" : \"검색어\"\n\n" +
+                    "}", authorizations = @Authorization(value = "Bearer +accessToken"))
+    @ApiResponses({
+            @ApiResponse(code = 200,
+                    message = "조회한 Inquiry 정보",
+                    response = InquiryResponse.class)
+    })
+    @GetMapping(value = "/inquiry/search/me/{search-word}")
+    public ResponseEntity<Page<InquiryResponse>> searchMyInquiries(@Validated InquiryCursorRequest inquiryCursorRequest, @ApiParam("검색어") @PathVariable(name = "search-word") String searchWord) throws Exception {
+        return new ResponseEntity<>(inquiryService.searchMyInquiries(inquiryCursorRequest, searchWord), HttpStatus.OK);
+    }
+
 }

--- a/src/main/java/com/jjbacsa/jjbacsabackend/inquiry/dto/request/InquiryCursorRequest.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/inquiry/dto/request/InquiryCursorRequest.java
@@ -1,0 +1,31 @@
+package com.jjbacsa.jjbacsabackend.inquiry.dto.request;
+
+import io.swagger.annotations.ApiParam;
+import lombok.*;
+import org.hibernate.validator.constraints.Range;
+
+import javax.annotation.Nullable;
+
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class InquiryCursorRequest {
+
+    @Nullable
+    @ApiParam("조회한 마지막 Inquiry의 Id")
+    private Long idCursor;
+
+    @Nullable
+    @ApiParam("조회한 마지막 Inquiry의 생성일")
+    private String dateCursor;
+
+
+    @Builder.Default
+    @ApiParam("조회할 개수")
+    @Range(min = 1, max = 100, message = "size의 범위는 1 ~ 100 입니다.")
+    private int size = 3;
+
+}
+

--- a/src/main/java/com/jjbacsa/jjbacsabackend/inquiry/dto/response/InquiryResponse.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/inquiry/dto/response/InquiryResponse.java
@@ -1,12 +1,14 @@
 package com.jjbacsa.jjbacsabackend.inquiry.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.jjbacsa.jjbacsabackend.inquiry_image.dto.response.InquiryImageResponse;
 import lombok.*;
 
 import java.util.Date;
 import java.util.List;
 
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 @Getter
 @Builder
 @AllArgsConstructor

--- a/src/main/java/com/jjbacsa/jjbacsabackend/inquiry/mapper/InquiryMapper.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/inquiry/mapper/InquiryMapper.java
@@ -25,4 +25,9 @@ public interface InquiryMapper {
 
     @Mapping(source = "writer.nickname", target = "createdBy")
     InquiryResponse toInquiryResponse(InquiryEntity inquiryEntity);
+
+    @Mapping(target = "content", ignore = true)
+    @Mapping(target = "answer", ignore = true)
+    @Mapping(target = "inquiryImages", ignore = true)
+    InquiryResponse toInquiryPageResponse(InquiryEntity inquiryEntity);
 }

--- a/src/main/java/com/jjbacsa/jjbacsabackend/inquiry/mapper/InquiryMapper.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/inquiry/mapper/InquiryMapper.java
@@ -29,5 +29,6 @@ public interface InquiryMapper {
     @Mapping(target = "content", ignore = true)
     @Mapping(target = "answer", ignore = true)
     @Mapping(target = "inquiryImages", ignore = true)
+    @Mapping(source = "writer.nickname", target = "createdBy")
     InquiryResponse toInquiryPageResponse(InquiryEntity inquiryEntity);
 }

--- a/src/main/java/com/jjbacsa/jjbacsabackend/inquiry/repository/InquiryRepository.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/inquiry/repository/InquiryRepository.java
@@ -1,9 +1,10 @@
 package com.jjbacsa.jjbacsabackend.inquiry.repository;
 
 import com.jjbacsa.jjbacsabackend.inquiry.entity.InquiryEntity;
+import com.jjbacsa.jjbacsabackend.inquiry.repository.querydsl.DslInquiryRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface InquiryRepository extends JpaRepository<InquiryEntity, Long> {
+public interface InquiryRepository extends JpaRepository<InquiryEntity, Long>, DslInquiryRepository {
 }

--- a/src/main/java/com/jjbacsa/jjbacsabackend/inquiry/repository/querydsl/DslInquiryRepository.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/inquiry/repository/querydsl/DslInquiryRepository.java
@@ -1,0 +1,14 @@
+package com.jjbacsa.jjbacsabackend.inquiry.repository.querydsl;
+
+import com.jjbacsa.jjbacsabackend.inquiry.dto.request.InquiryCursorRequest;
+import com.jjbacsa.jjbacsabackend.inquiry.entity.InquiryEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface DslInquiryRepository {
+    Page<InquiryEntity> findAllInquiries(String dateCursor, Long idCursor, Pageable pageable);
+    Page<InquiryEntity> findAllMyInquiries(String dateCursor, Long idCursor, Long userId, Pageable pageable);
+    Page<InquiryEntity> findAllSearchInquiries(String dateCursor, Long idCursor, String searchWord, Pageable pageable);
+    Page<InquiryEntity> findAllSearchMyInquiries(String dateCursor, Long idCursor, String searchWord, Long userId, Pageable pageable);
+
+}

--- a/src/main/java/com/jjbacsa/jjbacsabackend/inquiry/repository/querydsl/DslInquiryRepository.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/inquiry/repository/querydsl/DslInquiryRepository.java
@@ -7,8 +7,11 @@ import org.springframework.data.domain.Pageable;
 
 public interface DslInquiryRepository {
     Page<InquiryEntity> findAllInquiries(String dateCursor, Long idCursor, Pageable pageable);
+
     Page<InquiryEntity> findAllMyInquiries(String dateCursor, Long idCursor, Long userId, Pageable pageable);
+
     Page<InquiryEntity> findAllSearchInquiries(String dateCursor, Long idCursor, String searchWord, Pageable pageable);
+
     Page<InquiryEntity> findAllSearchMyInquiries(String dateCursor, Long idCursor, String searchWord, Long userId, Pageable pageable);
 
 }

--- a/src/main/java/com/jjbacsa/jjbacsabackend/inquiry/repository/querydsl/DslInquiryRepositoryImpl.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/inquiry/repository/querydsl/DslInquiryRepositoryImpl.java
@@ -1,0 +1,114 @@
+package com.jjbacsa.jjbacsabackend.inquiry.repository.querydsl;
+
+import com.jjbacsa.jjbacsabackend.inquiry.dto.request.InquiryCursorRequest;
+import com.jjbacsa.jjbacsabackend.inquiry.entity.InquiryEntity;
+import com.jjbacsa.jjbacsabackend.inquiry.entity.QInquiryEntity;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.StringExpressions;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Slf4j
+@Repository
+public class DslInquiryRepositoryImpl extends QuerydslRepositorySupport implements DslInquiryRepository {
+    private final JPAQueryFactory queryFactory;
+    private static QInquiryEntity inquiry = QInquiryEntity.inquiryEntity;
+
+    public DslInquiryRepositoryImpl(JPAQueryFactory queryFactory) {
+        super(InquiryEntity.class);
+        this.queryFactory = queryFactory;
+    }
+
+    @Override
+    public Page<InquiryEntity> findAllInquiries(String dateCursor, Long idCursor, Pageable pageable) {
+
+        List<InquiryEntity> inquiryEntities = queryFactory
+                .selectFrom(inquiry)
+                .where(customCursor(dateCursor, idCursor))
+                .limit(pageable.getPageSize())
+                .orderBy(inquiry.createdAt.desc(), inquiry.id.desc())
+                .fetch();
+
+        JPAQuery<Long> countQuery = queryFactory
+                .select(inquiry.count())
+                .from(inquiry);
+
+        return PageableExecutionUtils.getPage(inquiryEntities, pageable, countQuery::fetchOne);
+    }
+
+    @Override
+    public Page<InquiryEntity> findAllMyInquiries(String dateCursor, Long idCursor, Long userId, Pageable pageable) {
+
+        List<InquiryEntity> inquiryEntities = queryFactory
+                .selectFrom(inquiry)
+                .where(inquiry.writer.id.eq(userId),
+                        customCursor(dateCursor, idCursor))
+                .limit(pageable.getPageSize())
+                .orderBy(inquiry.createdAt.desc(), inquiry.id.desc())
+                .fetch();
+
+        JPAQuery<Long> countQuery = queryFactory
+                .select(inquiry.count())
+                .where(inquiry.writer.id.eq(userId))
+                .from(inquiry);
+
+        return PageableExecutionUtils.getPage(inquiryEntities, pageable, countQuery::fetchOne);
+    }
+
+    @Override
+    public Page<InquiryEntity> findAllSearchInquiries(String dateCursor, Long idCursor, String searchWord, Pageable pageable) {
+        List<InquiryEntity> inquiryEntities = queryFactory
+                .selectFrom(inquiry)
+                .where(inquiry.title.contains(searchWord),
+                        customCursor(dateCursor, idCursor))
+                .limit(pageable.getPageSize())
+                .orderBy(inquiry.createdAt.desc(), inquiry.id.desc())
+                .fetch();
+
+        JPAQuery<Long> countQuery = queryFactory
+                .select(inquiry.count())
+                .where(inquiry.title.contains(searchWord))
+                .from(inquiry);
+
+        return PageableExecutionUtils.getPage(inquiryEntities, pageable, countQuery::fetchOne);
+    }
+
+    @Override
+    public Page<InquiryEntity> findAllSearchMyInquiries(String dateCursor, Long idCursor, String searchWord, Long userId, Pageable pageable) {
+        List<InquiryEntity> inquiryEntities = queryFactory
+                .selectFrom(inquiry)
+                .where(inquiry.writer.id.eq(userId),
+                        inquiry.title.contains(searchWord),
+                        customCursor(dateCursor, idCursor))
+                .limit(pageable.getPageSize())
+                .orderBy(inquiry.createdAt.desc(), inquiry.id.desc())
+                .fetch();
+
+        JPAQuery<Long> countQuery = queryFactory
+                .select(inquiry.count())
+                .where(inquiry.writer.id.eq(userId),
+                        inquiry.title.contains(searchWord))
+                .from(inquiry);
+
+        return PageableExecutionUtils.getPage(inquiryEntities, pageable, countQuery::fetchOne);
+    }
+
+    private BooleanExpression customCursor(String dateCursor, Long idCursor) {
+        if(dateCursor == null || idCursor == null) return null;
+
+        StringBuilder sb = new StringBuilder(dateCursor);
+        sb.append(String.format("%1$" + 5 + "s", idCursor).replace(' ', '0'));
+
+        return inquiry.createdAt.stringValue().substring(0, 10)
+                .concat(StringExpressions.lpad(inquiry.id.stringValue(), 5, '0'))
+                .lt(sb.toString());
+    }
+}

--- a/src/main/java/com/jjbacsa/jjbacsabackend/inquiry/repository/querydsl/DslInquiryRepositoryImpl.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/inquiry/repository/querydsl/DslInquiryRepositoryImpl.java
@@ -102,7 +102,7 @@ public class DslInquiryRepositoryImpl extends QuerydslRepositorySupport implemen
     }
 
     private BooleanExpression customCursor(String dateCursor, Long idCursor) {
-        if(dateCursor == null || idCursor == null) return null;
+        if (dateCursor == null || idCursor == null) return null;
 
         StringBuilder sb = new StringBuilder(dateCursor);
         sb.append(String.format("%1$" + 5 + "s", idCursor).replace(' ', '0'));

--- a/src/main/java/com/jjbacsa/jjbacsabackend/inquiry/service/InquiryService.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/inquiry/service/InquiryService.java
@@ -1,8 +1,10 @@
 package com.jjbacsa.jjbacsabackend.inquiry.service;
 
 import com.jjbacsa.jjbacsabackend.inquiry.dto.request.AnswerRequest;
+import com.jjbacsa.jjbacsabackend.inquiry.dto.request.InquiryCursorRequest;
 import com.jjbacsa.jjbacsabackend.inquiry.dto.request.InquiryRequest;
 import com.jjbacsa.jjbacsabackend.inquiry.dto.response.InquiryResponse;
+import org.springframework.data.domain.Page;
 
 public interface InquiryService {
     InquiryResponse getInquiry(Long inquiryId) throws Exception;
@@ -14,4 +16,13 @@ public interface InquiryService {
     void delete(Long inquiryId) throws Exception;
 
     InquiryResponse addAnswer(AnswerRequest answer, Long inquiryId);
+
+    Page<InquiryResponse> getInquiries(InquiryCursorRequest inquiryCursorRequest);
+    Page<InquiryResponse> getMyInquiries(InquiryCursorRequest inquiryCursorRequest) throws Exception;
+
+    Page<InquiryResponse> searchInquiries(InquiryCursorRequest inquiryCursorRequest, String searchWord);
+
+    Page<InquiryResponse> searchMyInquiries(InquiryCursorRequest inquiryCursorRequest, String searchWord) throws Exception;
+
+
 }

--- a/src/main/java/com/jjbacsa/jjbacsabackend/inquiry/service/InquiryService.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/inquiry/service/InquiryService.java
@@ -18,6 +18,7 @@ public interface InquiryService {
     InquiryResponse addAnswer(AnswerRequest answer, Long inquiryId);
 
     Page<InquiryResponse> getInquiries(InquiryCursorRequest inquiryCursorRequest);
+
     Page<InquiryResponse> getMyInquiries(InquiryCursorRequest inquiryCursorRequest) throws Exception;
 
     Page<InquiryResponse> searchInquiries(InquiryCursorRequest inquiryCursorRequest, String searchWord);

--- a/src/main/java/com/jjbacsa/jjbacsabackend/inquiry/serviceImpl/InquiryServiceImpl.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/inquiry/serviceImpl/InquiryServiceImpl.java
@@ -56,7 +56,7 @@ public class InquiryServiceImpl implements InquiryService {
         if (inquiry.getWriter().equals(userEntity)) {
             inquiry.update(inquiryRequest);
             if (inquiryRequest.getInquiryImages() == null) {
-                for (int i = inquiry.getInquiryImages().size() -1; i >= 0; i--) {
+                for (int i = inquiry.getInquiryImages().size() - 1; i >= 0; i--) {
                     inquiryImageService.delete(inquiry.getInquiryImages().get(i));
                     inquiry.getInquiryImages().remove(i);
                 }

--- a/src/main/java/com/jjbacsa/jjbacsabackend/inquiry/serviceImpl/InquiryServiceImpl.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/inquiry/serviceImpl/InquiryServiceImpl.java
@@ -4,6 +4,7 @@ import com.jjbacsa.jjbacsabackend.etc.enums.ErrorMessage;
 import com.jjbacsa.jjbacsabackend.etc.enums.UserType;
 import com.jjbacsa.jjbacsabackend.etc.exception.RequestInputException;
 import com.jjbacsa.jjbacsabackend.inquiry.dto.request.AnswerRequest;
+import com.jjbacsa.jjbacsabackend.inquiry.dto.request.InquiryCursorRequest;
 import com.jjbacsa.jjbacsabackend.inquiry.dto.request.InquiryRequest;
 import com.jjbacsa.jjbacsabackend.inquiry.dto.response.InquiryResponse;
 import com.jjbacsa.jjbacsabackend.inquiry.entity.InquiryEntity;
@@ -16,6 +17,8 @@ import com.jjbacsa.jjbacsabackend.user.entity.UserEntity;
 import com.jjbacsa.jjbacsabackend.user.service.InternalUserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -75,6 +78,36 @@ public class InquiryServiceImpl implements InquiryService {
         InquiryEntity inquiry = getInquiryEntity(inquiryId);
         inquiry.setAnswer(answerRequest.getAnswer());
         return InquiryMapper.INSTANCE.toInquiryResponse(inquiry);
+    }
+
+    @Override
+    public Page<InquiryResponse> getInquiries(InquiryCursorRequest inquiryCursorRequest) {
+        return inquiryRepository
+                .findAllInquiries(inquiryCursorRequest.getDateCursor(), inquiryCursorRequest.getIdCursor(), PageRequest.ofSize(inquiryCursorRequest.getSize()))
+                .map(InquiryMapper.INSTANCE::toInquiryPageResponse);
+    }
+
+    @Override
+    public Page<InquiryResponse> getMyInquiries(InquiryCursorRequest inquiryCursorRequest) throws Exception {
+        UserEntity userEntity = userService.getLoginUser();
+        return inquiryRepository
+                .findAllMyInquiries(inquiryCursorRequest.getDateCursor(), inquiryCursorRequest.getIdCursor(), userEntity.getId(), PageRequest.ofSize(inquiryCursorRequest.getSize()))
+                .map(InquiryMapper.INSTANCE::toInquiryPageResponse);
+    }
+
+    @Override
+    public Page<InquiryResponse> searchInquiries(InquiryCursorRequest inquiryCursorRequest, String searchWord) {
+        return inquiryRepository
+                .findAllSearchInquiries(inquiryCursorRequest.getDateCursor(), inquiryCursorRequest.getIdCursor(), searchWord, PageRequest.ofSize(inquiryCursorRequest.getSize()))
+                .map(InquiryMapper.INSTANCE::toInquiryPageResponse);
+    }
+
+    @Override
+    public Page<InquiryResponse> searchMyInquiries(InquiryCursorRequest inquiryCursorRequest, String searchWord) throws Exception {
+        UserEntity userEntity = userService.getLoginUser();
+        return inquiryRepository
+                .findAllSearchMyInquiries(inquiryCursorRequest.getDateCursor(), inquiryCursorRequest.getIdCursor(), searchWord, userEntity.getId(), PageRequest.ofSize(inquiryCursorRequest.getSize()))
+                .map(InquiryMapper.INSTANCE::toInquiryPageResponse);
     }
 
     private InquiryEntity getInquiryEntity(Long inquiryId) {


### PR DESCRIPTION
문의하기

- `전체 문의 조회`, `나의 문의 조회`, `전체 문의 검색`, `나의 문의 검색` 기능 추가
- 커서 기반 페이징 : 최신순으로 정렬
- 리스트 조회에서는 `title`, `createdBy`, `createdAt`, `isSecreted` 필드만 제공

