### PR TITLE
유저 관련 API Validation 오류 수정 

### DIFF
--- a/src/main/java/com/jjbacsa/jjbacsabackend/scrap/controller/ScrapController.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/scrap/controller/ScrapController.java
@@ -51,7 +51,7 @@ public class ScrapController {
     @GetMapping(value = "/scraps/directories")
     public ResponseEntity<Page<ScrapDirectoryResponse>> getDirectories(
             @RequestParam(required = false) String cursor,
-            @ApiParam("가져올 데이터 수(1~100)") @Range(min = 1, max = 100) @RequestParam(required = false, defaultValue = "10") Integer pageSize) throws Exception {
+            @ApiParam("가져올 데이터 수(1~100)") @Range(min = 1, max = 100, message = "1에서 100 사이여야 합니다.") @RequestParam(required = false, defaultValue = "10") Integer pageSize) throws Exception {
 
         return new ResponseEntity<>(service.getDirectories(cursor, pageSize), HttpStatus.OK);
     }
@@ -115,7 +115,7 @@ public class ScrapController {
     public ResponseEntity<Page<ScrapResponse>> getScraps(
             @ApiParam("조회할 디렉토리 ID") @PathVariable(value = "directory_id", required = false) Long directoryId,
             @RequestParam(required = false) Long cursor,
-            @ApiParam("가져올 데이터 수(1~100)") @Range(min = 1, max = 100) @RequestParam(required = false, defaultValue = "10") Integer pageSize) throws Exception {
+            @ApiParam("가져올 데이터 수(1~100)") @Range(min = 1, max = 100, message = "1에서 100 사이여야 합니다.") @RequestParam(required = false, defaultValue = "10") Integer pageSize) throws Exception {
 
         return new ResponseEntity<>(service.getScraps(directoryId, cursor, pageSize), HttpStatus.OK);
     }
@@ -157,7 +157,7 @@ public class ScrapController {
     @PreAuthorize("hasRole('NORMAL')")
     public ResponseEntity <Page<ShopScrapResponse>> getUserScrapShops(@ApiParam("조회할 사용자 ID") @RequestParam(required=false, name = "user") Long userId,
                                                                       @RequestParam(required = false) Long cursor,
-                                                                      @ApiParam("가져올 데이터 수(1~100)") @Range(min = 1, max = 100) @RequestParam(required = false, defaultValue = "10") Integer pageSize) throws Exception {
+                                                                      @ApiParam("가져올 데이터 수(1~100)") @Range(min = 1, max = 100, message = "1에서 100 사이여야 합니다.") @RequestParam(required = false, defaultValue = "10") Integer pageSize) throws Exception {
 
         return ResponseEntity.ok(service.getScrapShops(userId, cursor, pageSize));
     }

--- a/src/main/java/com/jjbacsa/jjbacsabackend/user/controller/UserController.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/user/controller/UserController.java
@@ -79,7 +79,7 @@ public class UserController {
     })
     @GetMapping(value = "/user/exists")
     public ResponseEntity<String> checkDuplicateAccount(
-            @Pattern(regexp = "^[a-zA-z가-힣0-9]{1,20}$", message = "닉네임에 특수문자와 초성은 불가능합니다.")
+            @Pattern(regexp = "^[a-zA-Z0-9]{1,20}$", message = "올바른 형식의 아이디가 아닙니다.")
             @RequestParam String account) throws Exception {
         return new ResponseEntity<>(userService.checkDuplicateAccount(account), HttpStatus.OK);
     }

--- a/src/main/java/com/jjbacsa/jjbacsabackend/user/controller/UserController.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/user/controller/UserController.java
@@ -269,7 +269,9 @@ public class UserController {
                     message = "OK")
     })
     @PostMapping("/user/email/password")
-    public ResponseEntity<String> sendAuthEmailPassword(@RequestParam String account,
+    public ResponseEntity<String> sendAuthEmailPassword(
+                                                        @Pattern(regexp = "^[a-zA-Z0-9]{1,20}$", message = "올바른 형식의 아이디가 아닙니다.")
+                                                        @RequestParam String account,
                                                         @Email(message = "이메일은 형식을 지켜야 합니다.")
                                                         @RequestParam String email) throws Exception {
         userService.sendAuthEmailCode(account, email);


### PR DESCRIPTION
- 유저 API쪽 Validation 에러 메세지가 원인과 다른 오류 수정

### 수정사항
- 아이디 중복 체크 시 아이디 Validation 및 메시지 수정
- 유저 비밀번호 찾기 메일 발송의 아이디 Validation 추가