### PR TITLE
순환참조 리팩토링

### DIFF
--- a/src/main/java/com/jjbacsa/jjbacsabackend/google/service/InternalGoogleApiService.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/google/service/InternalGoogleApiService.java
@@ -1,0 +1,16 @@
+package com.jjbacsa.jjbacsabackend.google.service;
+
+import com.jjbacsa.jjbacsabackend.google.dto.response.ShopResponse;
+import com.jjbacsa.jjbacsabackend.google.dto.response.ShopScrapResponse;
+import com.jjbacsa.jjbacsabackend.google.entity.GoogleShopEntity;
+import com.jjbacsa.jjbacsabackend.scrap.entity.ScrapEntity;
+
+public interface InternalGoogleApiService {
+
+    GoogleShopEntity getGoogleShopByPlaceId(String placeId);
+
+    ShopResponse getShopDetails(String placeId) throws Exception;
+
+    ShopScrapResponse formattedToShopResponse(ScrapEntity scrap) throws Exception;
+
+}

--- a/src/main/java/com/jjbacsa/jjbacsabackend/google/service/InternalGoogleService.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/google/service/InternalGoogleService.java
@@ -1,28 +1,15 @@
 package com.jjbacsa.jjbacsabackend.google.service;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.jjbacsa.jjbacsabackend.google.dto.response.ShopScrapResponse;
 import com.jjbacsa.jjbacsabackend.google.entity.GoogleShopEntity;
-import com.jjbacsa.jjbacsabackend.google.dto.response.ShopResponse;
-import com.jjbacsa.jjbacsabackend.scrap.entity.ScrapEntity;
-
-import java.util.List;
 
 public interface InternalGoogleService {
-    GoogleShopEntity getGoogleShopByPlaceId(String placeId);
 
     GoogleShopEntity getGoogleShopById(Long shopId);
-
-    ShopResponse getShopDetails(String placeId) throws Exception;
 
     void addTotalRating(Long shopId, int delta);
 
     void increaseRatingCount(Long shopId);
 
     void decreaseRatingCount(Long shopId);
-
-    ShopScrapResponse formattedToShopResponse(ScrapEntity scrap) throws Exception;
-
-
 
 }

--- a/src/main/java/com/jjbacsa/jjbacsabackend/google/serviceImpl/InternalGoogleApiServiceImpl.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/google/serviceImpl/InternalGoogleApiServiceImpl.java
@@ -1,0 +1,59 @@
+package com.jjbacsa.jjbacsabackend.google.serviceImpl;
+
+import com.jjbacsa.jjbacsabackend.etc.enums.ErrorMessage;
+import com.jjbacsa.jjbacsabackend.etc.exception.ApiException;
+import com.jjbacsa.jjbacsabackend.google.dto.response.ShopResponse;
+import com.jjbacsa.jjbacsabackend.google.dto.response.ShopScrapResponse;
+import com.jjbacsa.jjbacsabackend.google.entity.GoogleShopEntity;
+import com.jjbacsa.jjbacsabackend.google.repository.GoogleShopRepository;
+import com.jjbacsa.jjbacsabackend.google.service.GoogleShopService;
+import com.jjbacsa.jjbacsabackend.google.service.InternalGoogleApiService;
+import com.jjbacsa.jjbacsabackend.scrap.entity.ScrapEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class InternalGoogleApiServiceImpl implements InternalGoogleApiService {
+
+    private final GoogleShopRepository googleShopRepository;
+    private final GoogleShopService googleShopService;
+
+    @Override
+    public GoogleShopEntity getGoogleShopByPlaceId(String placeId) {
+
+        return googleShopRepository.findByPlaceId(placeId)
+                .orElseGet(() -> {
+                    try {
+                        return saveGoogleShop(placeId);
+                    } catch (Exception e) {
+                        throw new ApiException(ErrorMessage.NOT_FOUND_EXCEPTION);
+                    }
+                });
+    }
+
+    @Override
+    public ShopResponse getShopDetails(String placeId) throws Exception {
+
+        return googleShopService.getShopDetails(placeId, true);
+    }
+
+    @Override
+    public ShopScrapResponse formattedToShopResponse(ScrapEntity scrap) throws Exception {
+
+        ShopScrapResponse shopScrapResponse = googleShopService.getShopScrap(scrap.getShop().getPlaceId(), scrap.getId());
+        return shopScrapResponse;
+    }
+
+    private GoogleShopEntity saveGoogleShop(String placeId) throws Exception {
+
+        ShopResponse shopResponse = googleShopService.getShopDetails(placeId, false);
+        GoogleShopEntity googleShopEntity = GoogleShopEntity.builder()
+                .placeId(shopResponse.getPlaceId())
+                .build();
+
+        return googleShopRepository.save(googleShopEntity);
+    }
+}

--- a/src/main/java/com/jjbacsa/jjbacsabackend/google/serviceImpl/InternalGoogleServiceImpl.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/google/serviceImpl/InternalGoogleServiceImpl.java
@@ -1,22 +1,13 @@
 package com.jjbacsa.jjbacsabackend.google.serviceImpl;
 
 import com.jjbacsa.jjbacsabackend.etc.enums.ErrorMessage;
-import com.jjbacsa.jjbacsabackend.etc.exception.ApiException;
-import com.jjbacsa.jjbacsabackend.etc.exception.BaseException;
 import com.jjbacsa.jjbacsabackend.etc.exception.RequestInputException;
-import com.jjbacsa.jjbacsabackend.google.dto.response.ShopScrapResponse;
 import com.jjbacsa.jjbacsabackend.google.entity.GoogleShopEntity;
 import com.jjbacsa.jjbacsabackend.google.repository.GoogleShopRepository;
-import com.jjbacsa.jjbacsabackend.google.dto.response.ShopResponse;
-import com.jjbacsa.jjbacsabackend.google.service.GoogleShopService;
 import com.jjbacsa.jjbacsabackend.google.service.InternalGoogleService;
-import com.jjbacsa.jjbacsabackend.scrap.entity.ScrapEntity;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -24,20 +15,6 @@ import java.util.stream.Collectors;
 public class InternalGoogleServiceImpl implements InternalGoogleService {
 
     private final GoogleShopRepository googleShopRepository;
-    private final GoogleShopService googleService;
-
-    @Override
-    public GoogleShopEntity getGoogleShopByPlaceId(String placeId) {
-
-        return googleShopRepository.findByPlaceId(placeId)
-                .orElseGet(() -> {
-                    try {
-                        return saveGoogleShop(placeId);
-                    } catch (Exception e) {
-                        throw new ApiException(ErrorMessage.NOT_FOUND_EXCEPTION);
-                    }
-                });
-    }
 
     @Override
     @Transactional(readOnly = true)
@@ -45,12 +22,6 @@ public class InternalGoogleServiceImpl implements InternalGoogleService {
 
         return googleShopRepository.findById(shopId)
                 .orElseThrow(() -> new RequestInputException(ErrorMessage.SHOP_NOT_EXISTS_EXCEPTION));
-    }
-
-    @Override
-    @Transactional(readOnly = true)
-    public ShopResponse getShopDetails(String placeId) throws Exception {
-        return googleService.getShopDetails(placeId, true);
     }
 
     @Override
@@ -74,18 +45,4 @@ public class InternalGoogleServiceImpl implements InternalGoogleService {
         shop.getShopCount().setRatingCount(googleShopRepository.getRatingCount(shopId) - 1);
     }
 
-    private GoogleShopEntity saveGoogleShop(String placeId) throws Exception {
-        ShopResponse shopResponse = googleService.getShopDetails(placeId, true);
-        GoogleShopEntity googleShopEntity = GoogleShopEntity.builder()
-                .placeId(shopResponse.getPlaceId())
-                .build();
-
-        return googleShopRepository.save(googleShopEntity);
-    }
-
-    @Override
-    public ShopScrapResponse formattedToShopResponse(ScrapEntity scrap) throws Exception {
-        ShopScrapResponse shopScrapResponse = this.googleService.getShopScrap(scrap.getShop().getPlaceId(), scrap.getId());
-        return shopScrapResponse;
-    }
 }

--- a/src/main/java/com/jjbacsa/jjbacsabackend/review/service/InternalReviewService.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/review/service/InternalReviewService.java
@@ -11,4 +11,6 @@ public interface InternalReviewService {
 
     List<ReviewEntity> findReviewsByWriter(UserEntity user);
 
+    void deleteReviewsWithUser(UserEntity user);
+
 }

--- a/src/main/java/com/jjbacsa/jjbacsabackend/review/serviceImpl/InternalReviewServiceImpl.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/review/serviceImpl/InternalReviewServiceImpl.java
@@ -1,20 +1,27 @@
 package com.jjbacsa.jjbacsabackend.review.serviceImpl;
 
 import com.jjbacsa.jjbacsabackend.google.entity.GoogleShopEntity;
+import com.jjbacsa.jjbacsabackend.google.service.InternalGoogleService;
 import com.jjbacsa.jjbacsabackend.review.entity.ReviewEntity;
 import com.jjbacsa.jjbacsabackend.review.repository.ReviewRepository;
 import com.jjbacsa.jjbacsabackend.review.service.InternalReviewService;
+import com.jjbacsa.jjbacsabackend.review_image.entity.ReviewImageEntity;
+import com.jjbacsa.jjbacsabackend.review_image.service.InternalReviewImageService;
 import com.jjbacsa.jjbacsabackend.user.entity.UserEntity;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Service
+@Transactional(readOnly = true)
 public class InternalReviewServiceImpl implements InternalReviewService {
 
     private final ReviewRepository reviewRepository;
+    private final InternalReviewImageService reviewImageService;
+    private final InternalGoogleService shopService;
 
     @Override
     public List<Long> getReviewIdsForUser(UserEntity user) {
@@ -31,4 +38,24 @@ public class InternalReviewServiceImpl implements InternalReviewService {
 
         return reviewRepository.findAllByWriter(user);
     }
+
+    @Override
+    @Transactional
+    public void deleteReviewsWithUser(UserEntity user) {
+        List<ReviewEntity> reviews = reviewRepository.findAllByWriter(user);
+
+        for (ReviewEntity review : reviews) {
+
+            for (ReviewImageEntity reviewImage : review.getReviewImages()) { // 리뷰 이미지를 버킷에서 삭제
+                reviewImageService.delete(reviewImage);
+            }
+            review.setIsDeleted(1);
+
+            // 리뷰 수, 별점 처리
+            Long shopId = review.getShop().getId();
+            shopService.addTotalRating(shopId, -review.getRate());
+            shopService.decreaseRatingCount(shopId);
+        }
+    }
+
 }

--- a/src/main/java/com/jjbacsa/jjbacsabackend/review/serviceImpl/ReviewServiceImpl.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/review/serviceImpl/ReviewServiceImpl.java
@@ -5,6 +5,7 @@ import com.jjbacsa.jjbacsabackend.etc.exception.RequestInputException;
 import com.jjbacsa.jjbacsabackend.follow.service.InternalFollowService;
 import com.jjbacsa.jjbacsabackend.google.entity.GoogleShopEntity;
 import com.jjbacsa.jjbacsabackend.google.dto.response.ShopResponse;
+import com.jjbacsa.jjbacsabackend.google.service.InternalGoogleApiService;
 import com.jjbacsa.jjbacsabackend.google.service.InternalGoogleService;
 import com.jjbacsa.jjbacsabackend.review.dto.request.*;
 import com.jjbacsa.jjbacsabackend.review.dto.response.ReviewCountResponse;
@@ -39,6 +40,7 @@ import java.util.stream.Collectors;
 public class ReviewServiceImpl implements ReviewService {
     private final InternalUserService userService;
     private final InternalGoogleService shopService;
+    private final InternalGoogleApiService googleApiService;
     private final InternalFollowService followService;
     private final InternalReviewImageService reviewImageService;
 
@@ -185,7 +187,7 @@ public class ReviewServiceImpl implements ReviewService {
     private ReviewEntity createReviewEntity(ReviewRequest reviewRequest) throws Exception {
         UserEntity userEntity = userService.getLoginUser();
         log.info(reviewRequest.getPlaceId());
-        GoogleShopEntity shopEntity = shopService.getGoogleShopByPlaceId(reviewRequest.getPlaceId());
+        GoogleShopEntity shopEntity = googleApiService.getGoogleShopByPlaceId(reviewRequest.getPlaceId());
         ReviewEntity reviewEntity = ReviewEntity.builder()
                 .writer(userEntity)
                 .shop(shopEntity)
@@ -235,7 +237,7 @@ public class ReviewServiceImpl implements ReviewService {
         return shopPlaceIds.stream()
                 .map(placeId -> {
                     try {
-                        return shopService.getShopDetails(placeId);
+                        return googleApiService.getShopDetails(placeId);
                     } catch (Exception e) {
                         return null;
                     }

--- a/src/main/java/com/jjbacsa/jjbacsabackend/scrap/serviceimpl/ScrapServiceImpl.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/scrap/serviceimpl/ScrapServiceImpl.java
@@ -7,6 +7,7 @@ import com.jjbacsa.jjbacsabackend.etc.exception.RequestInputException;
 import com.jjbacsa.jjbacsabackend.google.dto.response.ShopResponse;
 import com.jjbacsa.jjbacsabackend.google.dto.response.ShopScrapResponse;
 import com.jjbacsa.jjbacsabackend.google.entity.GoogleShopEntity;
+import com.jjbacsa.jjbacsabackend.google.service.InternalGoogleApiService;
 import com.jjbacsa.jjbacsabackend.google.service.InternalGoogleService;
 import com.jjbacsa.jjbacsabackend.scrap.dto.ScrapDirectoryRequest;
 import com.jjbacsa.jjbacsabackend.scrap.dto.ScrapDirectoryResponse;
@@ -38,6 +39,7 @@ public class ScrapServiceImpl implements ScrapService {
 
     private final InternalUserService userService;
     private final InternalGoogleService shopService;
+    private final InternalGoogleApiService googleApiService;
 
     private final InternalScrapService scrapService;
 
@@ -97,7 +99,7 @@ public class ScrapServiceImpl implements ScrapService {
     public ScrapResponse create(ScrapRequest request) throws Exception {
 
         UserEntity user = userService.getLoginUser();
-        GoogleShopEntity shop = shopService.getGoogleShopByPlaceId(request.getPlaceId());
+        GoogleShopEntity shop = googleApiService.getGoogleShopByPlaceId(request.getPlaceId());
         ScrapDirectoryEntity directory = getDirectoryOrNull(request.getDirectoryId());
 
         if (directory != null)
@@ -143,7 +145,7 @@ public class ScrapServiceImpl implements ScrapService {
             @Override
             public ShopScrapResponse apply(ScrapEntity input) {
                 try {
-                    return shopService.formattedToShopResponse(input);
+                    return googleApiService.formattedToShopResponse(input);
                 } catch (Exception e) {
                     throw new BaseException(ErrorMessage.INTERNAL_SHOP_EXCEPTION);
                 }

--- a/src/main/java/com/jjbacsa/jjbacsabackend/user/serviceImpl/UserServiceImpl.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/user/serviceImpl/UserServiceImpl.java
@@ -244,22 +244,9 @@ public class UserServiceImpl implements UserService {
         followService.deleteFollowRequestWithUser(user);
 
         // 작성한 리뷰 및 리뷰 내 사진, 별점 삭제
-        List<ReviewEntity> reviews = reviewService.findReviewsByWriter(user);
-
-        for (ReviewEntity review : reviews) {
-
-            for (ReviewImageEntity reviewImage : review.getReviewImages()) { // 리뷰 이미지를 버킷에서 삭제
-                reviewImageService.delete(reviewImage);
-            }
-            review.setIsDeleted(1);
-
-            // 리뷰 수, 별점 처리
-            Long shopId = review.getShop().getId();
-            shopService.addTotalRating(shopId, -review.getRate());
-            shopService.decreaseRatingCount(shopId);
-        }
-
+        reviewService.deleteReviewsWithUser(user);
         user.getUserCount().setReviewCount(0);
+
         user.setIsDeleted(1);
 
         //회원 탈퇴에 따른 리프레시 토큰 삭제


### PR DESCRIPTION
#121 에서 발생했던 순환 참조 오류에 대해서 발생 지점을 파악하고 로직을 분리하여 이를 해결하였습니다

발생 지점  
 - InternalGoogleService에서 GoogleService를 참조하여 Google API를 사용하는 경우가 존재 
 - `InternalReview - InternalGoogleShop - ShopService - InternalReview`의 참조 발생

Internal Google Shop Service의 사용 상황:
1. DB의 데이터를 Read, Write
2. 외부 API 호출 -> 데이터 전달

두 레이어를 분리하여 해결
 - ShopService를 참조해야 하는 부분을 InternalGoogleApiService로 분리
 - 외부 API 호출은 Service 레이어에서 발생하므로 InternalService 사이의 순환참조가 발생하지 않음