### PR TITLE
인증 이메일 템플릿 추가

### DIFF
--- a/src/main/java/com/jjbacsa/jjbacsabackend/user/serviceImpl/InternalEmailServiceImpl.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/user/serviceImpl/InternalEmailServiceImpl.java
@@ -59,6 +59,11 @@ public class InternalEmailServiceImpl implements InternalEmailService {
         calendar.add(Calendar.SECOND, 5 * 60);
 
         String secret = getRandomNumber();
+        Map<String, Object> model = new HashMap<>();
+        model.put("authCode", secret);
+
+        Context context = new Context(Locale.KOREA, model);
+        String template = templateEngine.process("email_authenticate_code", context);
 
         if(userRepository.findByEmailAndPasswordIsNotNull(email).isPresent()) {
             AuthEmailEntity authEmail = AuthEmailEntity.builder()
@@ -72,7 +77,7 @@ public class InternalEmailServiceImpl implements InternalEmailService {
             authEmailRepository.save(authEmail);
         }
 
-        sesSender.sendMail(email, "쩝쩝박사 서비스 인증 메일입니다.", secret);
+        sesSender.sendMail(email, "쩝쩝박사 서비스 인증 메일입니다.", template);
     }
 
     @Override

--- a/src/main/resources/templates/email_authenticate_code.html
+++ b/src/main/resources/templates/email_authenticate_code.html
@@ -3,7 +3,7 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-  <title>쩝쩝박사 회원가입 인증</title>
+  <title>쩝쩝박사 이메일 인증</title>
 
   <link href="https://cdn.jsdelivr.net/gh/sunn-us/SUITE/fonts/static/woff2/SUITE.css" rel="stylesheet">
 </head>
@@ -39,7 +39,7 @@
 
             <div style="margin-top: 65px; color: #666666">
               이 인증번호는 1시간 뒤에 만료됩니다.<br>
-              만료시 회원가입을 다시 시도해주세요.<br>
+              만료시 인증 메일 요청을 다시 시도해주세요.<br>
             </div>
           </td>
         </tr>

--- a/src/main/resources/templates/email_authenticate_code.html
+++ b/src/main/resources/templates/email_authenticate_code.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>쩝쩝박사 회원가입 인증</title>
+
+  <link href="https://cdn.jsdelivr.net/gh/sunn-us/SUITE/fonts/static/woff2/SUITE.css" rel="stylesheet">
+</head>
+
+<body style="margin: 0; padding: 0;">
+<table align="center" border="0" cellpadding="0" cellspacing="0" width="600" style="border: 1px solid #cccccc;">
+  <tr>
+    <td align="center" bgcolor="#EAEAEA" style="padding: 40px 0 0 0;">
+      <!-- stage 수정 -->
+      <img src="https://static.api.stage.jjbaksa.com/logo/email_banner.png" alt="Creating Email Magic" width="1200px" height="416px" style="display: block;"/>
+    </td>
+  </tr>
+
+  <tr>
+    <td bgcolor="#ffffff" height="668px">
+      <table border="0" cellpadding="0" cellspacing="0" width="100%">
+        <tr>
+          <td style="margin: 88px 0 0 0; color: #000000; font-family: 'SUITE'; font-size: 49px; text-align: center;">
+            <b>이메일 주소 인증</b>
+          </td>
+        </tr>
+        <tr>
+          <td style="padding-top: 16px; text-align: center; font-family: 'SUITE'; font-size: 34px; color: #666666;">
+            <span>
+              아래의 인증번호를 쩝쩝박사에 입력해주세요.<br/>
+            </span>
+
+            <span style="margin-top: 77px; display: inline-block; height: 122px; width: 367px; background-color: #EEEEEE;">
+              <div style="font-size: 73px; font-family: 'SUITE'; color: #FF7F23; line-height: 120px">
+                <strong th:text="${authCode}"></strong>
+              </div>
+            </span>
+
+            <div style="margin-top: 65px; color: #666666">
+              이 인증번호는 1시간 뒤에 만료됩니다.<br>
+              만료시 회원가입을 다시 시도해주세요.<br>
+            </div>
+          </td>
+        </tr>
+
+      </table>
+    </td>
+  </tr>
+
+  <tr>
+    <td bgcolor="#2F2F2F" style="padding: 30px 30px 30px 30px;">
+      <table border="0" cellpadding="0" cellspacing="0" width="100%">
+        <tr>
+          <td width="75%" style="color:white; font-family: Arial, sans-serif;">
+            Copyright BCSD Lab, TEAM_JJBAKSA All rights reserved.
+          </td>
+        </tr>
+      </table>
+    </td>
+  </tr>
+</table>
+</body>
+</html>
+

--- a/src/main/resources/templates/register_authenticate.html
+++ b/src/main/resources/templates/register_authenticate.html
@@ -1,58 +1,66 @@
 <!DOCTYPE html>
 <html lang="ko" xmlns:th="http://www.thymeleaf.org">
 <head>
-    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <title>쩝쩝박사 회원가입 인증</title>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>쩝쩝박사 회원가입 인증</title>
+
+  <link href="https://cdn.jsdelivr.net/gh/sunn-us/SUITE/fonts/static/woff2/SUITE.css" rel="stylesheet">
 </head>
 
 <body style="margin: 0; padding: 0;">
 <table align="center" border="0" cellpadding="0" cellspacing="0" width="600" style="border: 1px solid #cccccc;">
-    <tr>
-        <td align="center" bgcolor="#EAEAEA" style="padding: 40px 0 30px 0;">
-            <!-- TODO : 이메일 인증 로고 변경 -->
-            <img src="https://static.koreatech.in/mail_form_logo.png" alt="Creating Email Magic" width="300" height="295" style="display: block;"/>
-        </td>
-    </tr>
-    <tr>
-        <td bgcolor="#ffffff" style="padding: 40px 30px 40px 30px;">
-            <table border="0" cellpadding="0" cellspacing="0" width="100%">
-                <tr>
-                    <td style="color: #153643; font-family: Arial, sans-serif; font-size: 24px; text-align: center;">
-                        <b>이메일 주소 인증</b>
-                    </td>
-                </tr>
-                <tr>
-                    <td style="padding: 20px 0 30px 0; text-align: center; font-family: Arial, sans-serif;">
-                        안녕하세요.<br><br>
-                        쩝쩝박사 운영팀입니다.<br>
-                        <br>
-                        회원 가입을 위해 이메일 주소를 인증해주세요.<br><br>
+  <tr>
+    <td align="center" bgcolor="#EAEAEA" style="padding: 40px 0 0 0;">
+      <!-- stage 수정 -->
+      <img src="https://static.api.stage.jjbaksa.com/logo/email_banner.png" alt="Creating Email Magic" width="1200px"
+           height="416px" style="display: block;"/>
+    </td>
+  </tr>
 
-                        <br><br>
-                        <a th:href="@{{contextPath}/user/check-email(contextPath=${contextPath}, access_token=${accessToken}, refresh_token=${refreshToken})}" style="background-color: #005C92; border: none; border-radius: 25px; color: white; padding: 15px 32px; text-align: center; text-decoration: none; display: inline-block; font-size: 16px;" class="btn">
-                            <b>이메일 주소 인증</b>
-                        </a>
+  <tr>
+    <td bgcolor="#ffffff" height="668px">
+      <table border="0" cellpadding="0" cellspacing="0" width="100%">
+        <tr>
+          <td style="margin: 88px 0 0 0; color: #000000; font-family: 'SUITE'; font-size: 49px; text-align: center;">
+            <b>이메일 주소 인증</b>
+          </td>
+        </tr>
+        <tr>
+          <td style="padding-top: 16px; text-align: center; font-family: 'SUITE'; font-size: 34px; color: #666666;">
+            <span>
+              아래의 버튼을 클릭하여 인증을 진행해주세요.<br/>
+            </span>
 
-                        <br><br>
-                        이 메일은 1시간 뒤에 만료됩니다. 만료시 회원가입을 다시 시도해주세요.<br>
-                    </td>
-                </tr>
+            <a th:href="@{{contextPath}/user/check-email(contextPath=${contextPath}, access_token=${accessToken}, refresh_token=${refreshToken})}"
+               style="margin-top: 50px; background-color: #FF7F23; border: none; border-radius: 25px; color: white; padding: 25px 32px; text-align: center; text-decoration: none; display: inline-block; font-size: 34px;"
+               class="btn">
+              <b>이메일 주소 인증</b>
+            </a>
 
-            </table>
-        </td>
-    </tr>
-    <tr>
-        <td bgcolor="#2F2F2F" style="padding: 30px 30px 30px 30px;">
-            <table border="0" cellpadding="0" cellspacing="0" width="100%">
-                <tr>
-                    <td width="75%" style="color:white; font-family: Arial, sans-serif;">
-                        Copyright BCSD Lab, TEAM_JJBAKSA All rights reserved.
-                    </td>
-                </tr>
-            </table>
-        </td>
-    </tr>
+            <div style="margin-top: 65px; color: #666666">
+              이 메일은 1시간 뒤에 만료됩니다.<br>
+              만료시 회원가입을 다시 시도해주세요.<br>
+            </div>
+          </td>
+        </tr>
+
+      </table>
+    </td>
+  </tr>
+
+  <tr>
+    <td bgcolor="#2F2F2F" style="padding: 30px 30px 30px 30px;">
+      <table border="0" cellpadding="0" cellspacing="0" width="100%">
+        <tr>
+          <td width="75%" style="color:white; font-family: Arial, sans-serif;">
+            Copyright BCSD Lab, TEAM_JJBAKSA All rights reserved.
+          </td>
+        </tr>
+      </table>
+    </td>
+  </tr>
 </table>
 </body>
 </html>
+


### PR DESCRIPTION
# 이메일 템플릿 추가

[피그마 페이지](https://www.figma.com/file/cte0vL1wZH8KQlfhO5hBIO/%EC%A9%9D%EC%A9%9D%EB%B0%95%EC%82%AC?type=design&node-id=9648-26184&mode=dev)

- 인증 이메일 템플릿 추가
- 회원가입 인증 템플릿이 따로 없어 버튼만 추가하여 진행했습니다.

![image](https://github.com/BCSDLab/JJBAKSA_BACK_END/assets/66675919/368894dd-bd63-4cc3-92b2-98e6b24300d5)

![image](https://github.com/BCSDLab/JJBAKSA_BACK_END/assets/66675919/f1b943a2-5384-4f1a-800b-e1996b7f8e11)
