### PR TITLE
사용자 검색 시 팔로우 상태 추가

### DIFF
--- a/src/main/java/com/jjbacsa/jjbacsabackend/etc/enums/FollowedType.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/etc/enums/FollowedType.java
@@ -1,5 +1,5 @@
 package com.jjbacsa.jjbacsabackend.etc.enums;
 
 public enum FollowedType {
-    NONE,REQUESTED,FOLLOWED
+    NONE,REQUEST_SENT, REQUEST_RECEIVED, FOLLOWED
 }

--- a/src/main/java/com/jjbacsa/jjbacsabackend/user/repository/querydsl/DslUserRepositoryImpl.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/user/repository/querydsl/DslUserRepositoryImpl.java
@@ -101,7 +101,7 @@ public class DslUserRepositoryImpl extends QuerydslRepositorySupport implements 
                 .leftJoin(qFollow).on(qFollow.user.eq(user), qFollow.follower.eq(qUser), qFollow.isDeleted.eq(0))
                 .where(qUser.in(users))
                 .fetch();
-        map = getFollowedType(map, tuples, FollowedType.FOLLOWED);
+        updateFollowedTypeMap(map, tuples, FollowedType.FOLLOWED);
 
         // Follow request check
         tuples = from(qUser)
@@ -109,7 +109,7 @@ public class DslUserRepositoryImpl extends QuerydslRepositorySupport implements 
                 .leftJoin(qFollowRequest).on(qFollowRequest.user.eq(user), qFollowRequest.follower.eq(qUser), qFollowRequest.isDeleted.eq(0))
                 .where(qUser.in(users))
                 .fetch();
-        map = getFollowedType(map, tuples, FollowedType.REQUEST_SENT);
+        updateFollowedTypeMap(map, tuples, FollowedType.REQUEST_SENT);
 
         // Follow request receive check
         tuples = from(qUser)
@@ -117,7 +117,7 @@ public class DslUserRepositoryImpl extends QuerydslRepositorySupport implements 
                 .leftJoin(qFollowRequest).on(qFollowRequest.follower.eq(user), qFollowRequest.user.eq(qUser), qFollowRequest.isDeleted.eq(0))
                 .where(qUser.in(users))
                 .fetch();
-        map = getFollowedType(map, tuples, FollowedType.REQUEST_RECEIVED);
+        updateFollowedTypeMap(map, tuples, FollowedType.REQUEST_RECEIVED);
 
         return map;
     }
@@ -126,14 +126,13 @@ public class DslUserRepositoryImpl extends QuerydslRepositorySupport implements 
         return tuple.get(0, Long.class);
     }
 
-    private Map<Long, FollowedType> getFollowedType(Map<Long, FollowedType> map, List<Tuple> tuples, FollowedType type) {
+    private void updateFollowedTypeMap(Map<Long, FollowedType> map, List<Tuple> tuples, FollowedType type) {
         for(Tuple tuple : tuples) {
             Long userId = getId(tuple);
             if (itemIsTrue(tuple, 1)) {
                 map.put(userId, type);
             } else if (!map.containsKey(userId)) map.put(userId, FollowedType.NONE);
         }
-        return map;
     }
 
     private boolean itemIsTrue(Tuple tuple, int index) {


### PR DESCRIPTION
사용자 검색 시 반환되는 팔로우 타입은
`NONE`, `REQUESTED`, `FOLLOWED` 세 가지 타입을 반환했는데
 - `내가 팔로우 요청을 보낸 사람인지`(send)를 체크하지 못하고 있었음
 - `쿼리 문제로 팔로우 요청 취소, 팔로우 취소 시 반영되지 않던 문제` 해결

쿼리 수정
 - `팔로우 요청 취소, 팔로우 취소 반영`
   - Entity에서 Where clause로 is_deleted=0이 반영되지만 join시에는 반영되지 않아 where 구문 수정
 
 - `NONE`, `REQUEST_SENT`, `REQUEST_RECEIVED`, `FOLLOWED` 타입으로 변경
 
 - 테이블 구조 상 `follower request` 테이블에서 user <-> follower가 cross되면서 `요청을 보낸사람` `요청을 받은사람`을 구분하고 있기 때문에 join을 하나 더 추가하면 `요청자 user`에 대해 데이터 중복이 발생
   - 복잡한 한방 쿼리를 사용하기 보다 각 join을 분리하는 방법 선택
   - 추후 인덱스 사용에도 적합하다고 판단하였음

쿼리 부분을 확인해서 피드백 주시면 감사하겠습니다