### PR TITLE
지도 내 상점 검색 시에 검색개수 제한

### DIFF
--- a/src/main/java/com/jjbacsa/jjbacsabackend/google/controller/GoogleShopController.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/google/controller/GoogleShopController.java
@@ -143,12 +143,12 @@ public class GoogleShopController {
             )
     })
     @ApiImplicitParams({
-            @ApiImplicitParam(name = "options_nearby", required = true, dataType = "Integer", value = "가까운 음식점 필터 여부"),
-            @ApiImplicitParam(name = "options_friend", required = true, dataType = "Integer", value = "친구 음식점 필터 여부"),
-            @ApiImplicitParam(name = "options_scrap", required = true, dataType = "Integer", value = "스크랩 음식점 필터 여부")
+            @ApiImplicitParam(name = "options_nearby", required = false, dataType = "Integer", value = "가까운 음식점 필터 여부"),
+            @ApiImplicitParam(name = "options_friend", required = false, dataType = "Integer", value = "친구 음식점 필터 여부"),
+            @ApiImplicitParam(name = "options_scrap", required = false, dataType = "Integer", value = "스크랩 음식점 필터 여부")
     })
     @PostMapping("/shops/maps")
-    public ResponseEntity<List<ShopSimpleResponse>> getGoogleShops(@RequestParam(name = "options_nearby", required = false, defaultValue = "0") Integer nearBy,
+    public ResponseEntity<List<ShopSimpleResponse>> getGoogleShops(@RequestParam(name = "options_nearby", required = false, defaultValue = "1") Integer nearBy,
                                                                    @RequestParam(name = "options_friend", required = false, defaultValue = "0") Integer friend,
                                                                    @RequestParam(name = "options_scrap", required = false, defaultValue = "0") Integer scrap,
                                                                    @RequestBody @Valid ShopRequest shopRequest) throws Exception {

--- a/src/main/java/com/jjbacsa/jjbacsabackend/google/dto/SimpleShopDto.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/google/dto/SimpleShopDto.java
@@ -20,5 +20,5 @@ public class SimpleShopDto {
 
     private String name;
     private Geometry geometry;
-    private List<Photos> photo;
+    private List<Photos> photos;
 }

--- a/src/main/java/com/jjbacsa/jjbacsabackend/google/dto/response/ShopResponse.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/google/dto/response/ShopResponse.java
@@ -22,7 +22,7 @@ public class ShopResponse {
     private Double lng;
     private String formattedPhoneNumber;
     private Boolean openNow;
-    private String businessDay;
+    private List<String> businessDay;
     private Integer totalRating;
     private Integer ratingCount;
     private String category;

--- a/src/main/java/com/jjbacsa/jjbacsabackend/google/dto/response/ShopResponse.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/google/dto/response/ShopResponse.java
@@ -10,7 +10,7 @@ import java.util.List;
 /**
  * shopDto(단일 상점 자세한 정보) 반환되는 클래스
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
+//@JsonInclude(JsonInclude.Include.NON_NULL)
 @Builder
 @Getter
 public class ShopResponse {
@@ -27,17 +27,16 @@ public class ShopResponse {
     private Integer ratingCount;
     private String category;
     private String todayBusinessHour; //오늘 영업시간
-    private boolean isScrap;
+    private Long scrap;
     private List<String> photos;
-    private LocalDateTime lastReviewDate;
 
     public void setShopCount(Integer totalRating, Integer ratingCount) {
         this.totalRating = totalRating;
         this.ratingCount = ratingCount;
     }
 
-    public void setIsScrap(boolean isScrap) {
-        this.isScrap = isScrap;
+    public void setScrap(Long scrap) {
+        this.scrap = scrap;
     }
 
     public void setShopId(Long shopId) {

--- a/src/main/java/com/jjbacsa/jjbacsabackend/google/dto/response/ShopScrapResponse.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/google/dto/response/ShopScrapResponse.java
@@ -1,10 +1,14 @@
 package com.jjbacsa.jjbacsabackend.google.dto.response;
 
+import com.jjbacsa.jjbacsabackend.scrap.dto.ScrapDirectoryResponse;
 import lombok.Builder;
+import lombok.Data;
 import lombok.Getter;
 
-@Builder
+import java.util.Date;
+
 @Getter
+@Builder
 public class ShopScrapResponse {
     private String placeId;
     private String name;
@@ -12,11 +16,26 @@ public class ShopScrapResponse {
     private String category;
     private Integer totalRating;
     private Integer ratingCount;
-    private Long scrapId;
     private String address;
+
+    //scrap
+    private Long scrapId;
+    private Date createdAt;
+    private Date updatedAt;
+    private ScrapDirectoryResponse directory;
 
     public void setShopCount(Integer totalRating, Integer ratingCount) {
         this.totalRating = totalRating;
         this.ratingCount = ratingCount;
+    }
+
+    public void setScrapInfo(Long scrapId, Date createdAt, Date updatedAt) {
+        this.scrapId = scrapId;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    public void setDirectory(ScrapDirectoryResponse scrapDirectoryResponse){
+        this.directory=scrapDirectoryResponse;
     }
 }

--- a/src/main/java/com/jjbacsa/jjbacsabackend/google/serviceImpl/GoogleShopServiceImpl.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/google/serviceImpl/GoogleShopServiceImpl.java
@@ -209,6 +209,11 @@ public class GoogleShopServiceImpl implements GoogleShopService {
     public List<ShopSimpleResponse> getShops(Integer nearBy, Integer friend, Integer scrap, ShopRequest shopRequest) throws Exception {
 
         List<Long> shopIds = getShopId(nearBy, friend, scrap);
+
+        //현재 DB에 5개 이상 있으면 id 처음~5번째까지로 제한
+        if(shopIds.size()>5)
+            shopIds=shopIds.subList(0, 5);
+
         List<String> placeIDs = getPlaceIds(shopIds);
 
         // 2000m(2km) 이내

--- a/src/main/java/com/jjbacsa/jjbacsabackend/google/serviceImpl/GoogleShopServiceImpl.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/google/serviceImpl/GoogleShopServiceImpl.java
@@ -192,15 +192,15 @@ public class GoogleShopServiceImpl implements GoogleShopService {
         }
 
         Optional<GoogleShopEntity> shop = googleShopRepository.findByPlaceId(shopResponse.getPlaceId());
-        boolean isScrap = false;
+        Long scrapId = null;
         if (shop.isPresent()) {
             GoogleShopCount shopCount = shop.get().getShopCount();
             shopResponse.setShopCount(shopCount.getTotalRating(), shopCount.getRatingCount());
             shopResponse.setShopId(shop.get().getId());
-            isScrap = scrapService.isUserScrapShop(shop.get());
+            scrapId = scrapService.getUserScrapShop(shop.get());
         }
 
-        shopResponse.setIsScrap(isScrap);
+        shopResponse.setScrap(scrapId);
 
         return shopResponse;
     }

--- a/src/main/java/com/jjbacsa/jjbacsabackend/google/serviceImpl/GoogleShopServiceImpl.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/google/serviceImpl/GoogleShopServiceImpl.java
@@ -518,7 +518,7 @@ public class GoogleShopServiceImpl implements GoogleShopService {
 
                 String photoToken;
                 try {
-                    photoToken = getPhotoUrl(simpleShopDto.getPhoto().get(0).getPhotoReference());
+                    photoToken = getPhotoUrl(simpleShopDto.getPhotos().get(0).getPhotoReference());
                 } catch (NullPointerException e) {
                     photoToken = null;
                 }

--- a/src/main/java/com/jjbacsa/jjbacsabackend/google/serviceImpl/GoogleShopServiceImpl.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/google/serviceImpl/GoogleShopServiceImpl.java
@@ -211,8 +211,9 @@ public class GoogleShopServiceImpl implements GoogleShopService {
         List<Long> shopIds = getShopId(nearBy, friend, scrap);
 
         //현재 DB에 5개 이상 있으면 id 처음~5번째까지로 제한
-        if(shopIds.size()>5)
-            shopIds=shopIds.subList(0, 5);
+        int shopsSize= shopIds.size();
+        if(shopsSize>=5)
+            shopIds=shopIds.subList(shopsSize-5, shopsSize);
 
         List<String> placeIDs = getPlaceIds(shopIds);
 

--- a/src/main/java/com/jjbacsa/jjbacsabackend/google/serviceImpl/GoogleShopServiceImpl.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/google/serviceImpl/GoogleShopServiceImpl.java
@@ -58,7 +58,7 @@ public class GoogleShopServiceImpl implements GoogleShopService {
     private final InternalReviewService reviewService;
     private final InternalScrapService scrapService;
 
-    private final String[] placeDetailsField = {"formatted_address", "formatted_phone_number", "name", "geometry/location/lat", "geometry/location/lng", "types", "place_id", "opening_hours/open_now", "opening_hours/weekday_text", "photos/photo_reference"};
+    private final String[] placeDetailsField = {"formatted_address", "formatted_phone_number", "name", "geometry/location/lat", "geometry/location/lng", "types", "place_id", "opening_hours/open_now", "opening_hours/weekday_text", "opening_hours/periods", "photos/photo_reference"};
     private final String[] pinFields = {"name", "types", "place_id", "photos/photo_reference"};
     private final String[] simpleFields = {"geometry/location/lng", "geometry/location/lat", "place_id", "name", "photos/photo_reference"};
     private final String[] scrapFields = {"name", "types", "place_id", "photos/photo_reference", "formatted_address"};
@@ -144,24 +144,28 @@ public class GoogleShopServiceImpl implements GoogleShopService {
             List<String> businessDay=new ArrayList<>();
             String todayBusinessHour;
             try {
-                LocalDate today = LocalDate.now();
-                int dayOfWeek = today.getDayOfWeek().getValue() - 1;
 
-                for (String weekday : shopApiDto.getOpeningHours().getWeekdayText()) {
+                for (String weekday : shopApiDto.getOpeningHours().getWeekdayText())
                     businessDay.add(weekday.substring(5));
-                }
-                todayBusinessHour = shopApiDto.getOpeningHours().getWeekdayText().get(dayOfWeek);
-                todayBusinessHour = todayBusinessHour.substring(5);
 
-            } catch (NullPointerException e) {
+            } catch (Exception e) {
                 businessDay = null;
-                todayBusinessHour = null;
+            }
+
+            try{
+                LocalDate today = LocalDate.now();
+                int dayOfWeek = today.getDayOfWeek().getValue() -1; //0:월 6:일
+
+                todayBusinessHour=shopApiDto.getOpeningHours().getWeekdayText().get(dayOfWeek);
+                todayBusinessHour = todayBusinessHour.substring(5);
+            } catch (Exception e){
+                todayBusinessHour=null;
             }
 
             Boolean openNow;
             try {
                 openNow = (shopApiDto.getOpeningHours().getOpenNow() == "true") ? true : false;
-            } catch (NullPointerException e) {
+            } catch (Exception e) {
                 openNow = null;
             }
 

--- a/src/main/java/com/jjbacsa/jjbacsabackend/google/serviceImpl/InternalGoogleServiceImpl.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/google/serviceImpl/InternalGoogleServiceImpl.java
@@ -75,7 +75,7 @@ public class InternalGoogleServiceImpl implements InternalGoogleService {
     }
 
     private GoogleShopEntity saveGoogleShop(String placeId) throws Exception {
-        ShopResponse shopResponse = googleService.getShopDetails(placeId, true);
+        ShopResponse shopResponse = googleService.getShopDetails(placeId, false);
         GoogleShopEntity googleShopEntity = GoogleShopEntity.builder()
                 .placeId(shopResponse.getPlaceId())
                 .build();

--- a/src/main/java/com/jjbacsa/jjbacsabackend/scrap/controller/ScrapController.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/scrap/controller/ScrapController.java
@@ -113,7 +113,7 @@ public class ScrapController {
             authorizations = @Authorization(value = "Bearer + accessToken"))
     @PreAuthorize("hasRole('NORMAL')")
     @GetMapping(value = "/scraps/directories/{directory_id}")
-    public ResponseEntity<Page<ScrapResponse>> getScraps(
+    public ResponseEntity<Page<ShopScrapResponse>> getScraps(
             @ApiParam("조회할 디렉토리 ID") @PathVariable(value = "directory_id", required = false) Long directoryId,
             @RequestParam(required = false) Long cursor,
             @ApiParam("가져올 데이터 수(1~100)") @Range(min = 1, max = 100) @RequestParam(required = false, defaultValue = "10") Integer pageSize) throws Exception {

--- a/src/main/java/com/jjbacsa/jjbacsabackend/scrap/repository/ScrapRepository.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/scrap/repository/ScrapRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface ScrapRepository extends JpaRepository<ScrapEntity, Long>, DslScrapRepository {
@@ -16,4 +17,6 @@ public interface ScrapRepository extends JpaRepository<ScrapEntity, Long>, DslSc
     boolean existsByUserAndShop(UserEntity user, GoogleShopEntity shop);
 
     List<ScrapEntity> findAllByUser(UserEntity user);
+
+    Optional<ScrapEntity> findByUserAndShop(UserEntity user, GoogleShopEntity shop);
 }

--- a/src/main/java/com/jjbacsa/jjbacsabackend/scrap/service/InternalScrapService.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/scrap/service/InternalScrapService.java
@@ -17,7 +17,7 @@ public interface InternalScrapService {
 
     List<Long> getShopIdsForUserScrap() throws Exception;
 
-    boolean isUserScrapShop(GoogleShopEntity googleShop) throws Exception;
+    Long getUserScrapShop(GoogleShopEntity googleShop) throws Exception;
 }
 
 

--- a/src/main/java/com/jjbacsa/jjbacsabackend/scrap/service/ScrapService.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/scrap/service/ScrapService.java
@@ -20,7 +20,7 @@ public interface ScrapService {
 
     ScrapResponse create(ScrapRequest request) throws Exception;
 
-    Page<ScrapResponse> getScraps(Long directoryId, Long cursor, Integer pageSize) throws Exception;
+    Page<ShopScrapResponse> getScraps(Long directoryId, Long cursor, Integer pageSize) throws Exception;
 
     ScrapResponse move(Long scrapId, ScrapRequest request) throws Exception;
 

--- a/src/main/java/com/jjbacsa/jjbacsabackend/scrap/serviceimpl/InternalScrapServiceImpl.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/scrap/serviceimpl/InternalScrapServiceImpl.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -63,13 +64,18 @@ public class InternalScrapServiceImpl implements InternalScrapService {
 
     //상점 id와 사용자 id 비교해서 현재 사용자가 북마크 하는지 여부 반환
     @Override
-    public boolean isUserScrapShop(GoogleShopEntity googleShop) throws Exception {
+    public Long getUserScrapShop(GoogleShopEntity googleShop) throws Exception {
 
         //사용자가 로그아웃 된 상태이면
         if(!internalUserService.isUserLogin())
-            return false;
+            return null;
 
         UserEntity user=internalUserService.getLoginUser();
-        return scrapRepository.existsByUserAndShop(user, googleShop);
+        Optional<ScrapEntity> scrap= scrapRepository.findByUserAndShop(user, googleShop);
+
+        if(scrap.isPresent())
+            return scrap.get().getId();
+
+        return null;
     }
 }

--- a/src/main/java/com/jjbacsa/jjbacsabackend/scrap/serviceimpl/InternalScrapServiceImpl.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/scrap/serviceimpl/InternalScrapServiceImpl.java
@@ -64,13 +64,12 @@ public class InternalScrapServiceImpl implements InternalScrapService {
     //상점 id와 사용자 id 비교해서 현재 사용자가 북마크 하는지 여부 반환
     @Override
     public boolean isUserScrapShop(GoogleShopEntity googleShop) throws Exception {
-        UserEntity user;
-        try {
-            user = internalUserService.getLoginUser();
-        } catch (RequestInputException e) {
-            return false;
-        }
 
+        //사용자가 로그아웃 된 상태이면
+        if(!internalUserService.isUserLogin())
+            return false;
+
+        UserEntity user=internalUserService.getLoginUser();
         return scrapRepository.existsByUserAndShop(user, googleShop);
     }
 }

--- a/src/main/java/com/jjbacsa/jjbacsabackend/scrap/serviceimpl/ScrapServiceImpl.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/scrap/serviceimpl/ScrapServiceImpl.java
@@ -112,7 +112,7 @@ public class ScrapServiceImpl implements ScrapService {
 
     @Transactional(readOnly = true)
     @Override
-    public Page<ScrapResponse> getScraps(Long directoryId, Long cursor, Integer pageSize) throws Exception {
+    public Page<ShopScrapResponse> getScraps(Long directoryId, Long cursor, Integer pageSize) throws Exception {
 
         UserEntity user = userService.getLoginUser();
         ScrapDirectoryEntity directory = getDirectoryOrNull(directoryId);
@@ -122,7 +122,7 @@ public class ScrapServiceImpl implements ScrapService {
 
         Page<ScrapEntity> scraps = scrapRepository.findAllByUserAndDirectoryWithCursor(user, directory, cursor, PageRequest.of(0, pageSize));
 
-        return scraps.map(ScrapMapper.INSTANCE::toScrapResponse);
+        return scrapToShopScrapResponse(scraps,directory);
     }
 
     @Override
@@ -143,7 +143,7 @@ public class ScrapServiceImpl implements ScrapService {
             @Override
             public ShopScrapResponse apply(ScrapEntity input) {
                 try {
-                    ShopScrapResponse shopScrapResponse=shopService.formattedToShopResponse(input);
+                    ShopScrapResponse shopScrapResponse=googleApiService.formattedToShopResponse(input);
                     shopScrapResponse.setScrapInfo(input.getId(), input.getCreatedAt(), input.getUpdatedAt());
 
                     if(directory==null){

--- a/src/main/java/com/jjbacsa/jjbacsabackend/user/service/InternalUserService.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/user/service/InternalUserService.java
@@ -28,4 +28,5 @@ public interface InternalUserService {
     void decreaseFriendCount(Long userId);
 
     void addScrapCount(Long userId, int delta);
+    boolean isUserLogin();
 }

--- a/src/main/java/com/jjbacsa/jjbacsabackend/user/serviceImpl/InternalUserServiceImpl.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/user/serviceImpl/InternalUserServiceImpl.java
@@ -50,6 +50,19 @@ public class InternalUserServiceImpl implements InternalUserService {
     }
 
     @Override
+    public boolean isUserLogin(){
+        Object principal = SecurityContextHolder
+                .getContext()
+                .getAuthentication()
+                .getPrincipal();
+
+        if (principal == null || principal.toString().equals("anonymousUser"))
+            return false;
+
+        return true;
+    }
+
+    @Override
     public UserEntity getUserByEmail(String email) throws RequestInputException {
         return userRepository.findByEmail(email)
                 .orElseThrow(() -> new RequestInputException(ErrorMessage.USER_NOT_EXISTS_EXCEPTION));

--- a/src/test/java/com/jjbacsa/jjbacsabackend/google/service/GoogleShopServiceTest.java
+++ b/src/test/java/com/jjbacsa/jjbacsabackend/google/service/GoogleShopServiceTest.java
@@ -298,7 +298,7 @@ public class GoogleShopServiceTest {
         }
 
         List<ShopSimpleResponse> responses=googleShopService.getShops(1, 0, 0, shopRequest);
-        Assertions.assertEquals(5, responses.size());
+        Assertions.assertEquals(3, responses.size());
     }
 
     private void saveAllShops() {

--- a/src/test/java/com/jjbacsa/jjbacsabackend/google/service/GoogleShopServiceTest.java
+++ b/src/test/java/com/jjbacsa/jjbacsabackend/google/service/GoogleShopServiceTest.java
@@ -279,6 +279,28 @@ public class GoogleShopServiceTest {
         Assertions.assertNotEquals(result.size(),0);
     }
 
+    @Transactional
+    @Test
+    public void 갯수제한지도검색() throws Exception {
+        /** 상점 8개->결과 5개의 상점
+        반경 제한이 있으므로 request 근처의 상점 저장
+         */
+
+        String[] placeIds={"ChIJe9073fyefDUR4FggnKorNT4", "ChIJ2VpIAuOefDURiSzLpLD7OxI", "ChIJ3dyD-uKefDURvS4uxk4WFK4",
+                "ChIJW3qxgvuefDURVsRM2EnFCz4", "ChIJj6rxJyCffDURkVhCG8vD3i4", "ChIJIT3KvvuefDURlP-mhml8T6A",
+                "ChIJp6SCj_uefDURuP72bKM72O8", "ChIJfeRTqv6efDURoL4B-l4wrsA"};
+
+        for(String id:placeIds){
+            GoogleShopEntity googleShop=GoogleShopEntity.builder()
+                    .placeId(id).build();
+
+            googleShopRepository.save(googleShop);
+        }
+
+        List<ShopSimpleResponse> responses=googleShopService.getShops(1, 0, 0, shopRequest);
+        Assertions.assertEquals(5, responses.size());
+    }
+
     private void saveAllShops() {
         googleShopRepository.save(googleShop1);
         googleShopRepository.save(googleShop2);

--- a/src/test/java/com/jjbacsa/jjbacsabackend/google/service/GoogleShopServiceTest.java
+++ b/src/test/java/com/jjbacsa/jjbacsabackend/google/service/GoogleShopServiceTest.java
@@ -116,10 +116,12 @@ public class GoogleShopServiceTest {
     @Transactional
     @Test
     public void 상점_메인페이지_가까운필터() throws Exception {
-        saveAllShops();
+        int alreadyStored=googleShopRepository.findAll().size();
 
+        saveAllShops();
         List<ShopSimpleResponse> shops = googleShopService.getShops(1, 0, 0, shopRequest);
-        Assertions.assertEquals(4, shops.size());
+
+        Assertions.assertEquals(4+alreadyStored, shops.size());
 
         shops.stream().forEach(s -> {
             Assertions.assertEquals(s.getPlaceId(), googleShopRepository.findByPlaceId(s.getPlaceId()).get().getPlaceId());
@@ -127,7 +129,6 @@ public class GoogleShopServiceTest {
 
     }
 
-    //todo: 필터 테스트
     @Transactional
     @Test
     public void 상점_메인페이지_친구필터() throws Exception {
@@ -163,9 +164,6 @@ public class GoogleShopServiceTest {
         reviewRepository.save(reviewEntity1);
         reviewRepository.save(reviewEntity2);
         reviewRepository.save(reviewEntity3);
-
-//        List<ShopSimpleResponse> results=this.googleShopService.getShops(0,0,0,shopRequest);
-//        Assertions.assertEquals(results.size(),0);
 
         List<ShopSimpleResponse> results2 = this.googleShopService.getShops(0, 1, 0, shopRequest);
         Assertions.assertEquals(2, results2.size());
@@ -263,10 +261,10 @@ public class GoogleShopServiceTest {
         scrapRepository.save(scrap1);
 
         ShopResponse shopResponse = googleShopService.getShopDetails(googleShop1.getPlaceId(), true);
-        Assertions.assertEquals(shopResponse.isScrap(), true);
+        Assertions.assertNotNull(shopResponse.getScrap());
 
         ShopResponse shopResponse2 = googleShopService.getShopDetails(googleShop2.getPlaceId(), true);
-        Assertions.assertEquals(shopResponse2.isScrap(), false);
+        Assertions.assertNull(shopResponse2.getScrap());
     }
 
     @Test
@@ -280,7 +278,6 @@ public class GoogleShopServiceTest {
         List<String> result = googleShopService.getAutoComplete("순대", autoCompleteRequest);
         Assertions.assertNotEquals(result.size(),0);
     }
-
 
     private void saveAllShops() {
         googleShopRepository.save(googleShop1);

--- a/src/test/java/com/jjbacsa/jjbacsabackend/scrap/service/ScrapServiceTest.java
+++ b/src/test/java/com/jjbacsa/jjbacsabackend/scrap/service/ScrapServiceTest.java
@@ -246,43 +246,43 @@ class ScrapServiceTest {
         assertEquals(2, user1.getUserCount().getScrapCount());
     }
 
-    @DisplayName("스크랩 목록 조회")
-    @Test
-    void getScraps() throws Exception {
-
-        //테스트 데이터 생성
-        ScrapDirectoryEntity directory1 = scrapDirectoryRepository.save(getTestDirectory(user1, "dir1"));
-        ScrapDirectoryEntity directory2 = scrapDirectoryRepository.save(getTestDirectory(user2, "dir2"));
-
-        for (GoogleShopEntity googleShop : googleShops) {
-            scrapRepository.save(getTestScrap(user1, googleShop, null));
-            scrapRepository.save(getTestScrap(user1, googleShop, directory1));
-        }
-
-        //디렉토리가 없는 경우
-        testLogin(user1);
-        assertThrows(RuntimeException.class, () ->
-                scrapService.getScraps(null, null, 10)
-        );
-
-        //내가 만든 디렉토리가 아닌 경우
-        assertThrows(RuntimeException.class, () ->
-                scrapService.getScraps(directory2.getId(), null, 10)
-        );
-
-        //스크랩 조회
-        Page<ScrapResponse> page1_1 = scrapService.getScraps(0L, null, 10);
-        Page<ScrapResponse> page1_2 = scrapService.getScraps(0L, page1_1.getContent().get(4).getId(), 10);
-        Page<ScrapResponse> page2_1 = scrapService.getScraps(directory1.getId(), null, 10);
-        Page<ScrapResponse> page2_2 = scrapService.getScraps(directory1.getId(), page2_1.getContent().get(4).getId(), 10);
-
-        //then
-        assertEquals(5, page1_2.getContent().size());
-        assertEquals(5, page2_2.getContent().size());
-        assertEquals(page1_1.getContent().get(5).getId(), page1_2.getContent().get(0).getId());
-        assertEquals(page2_1.getContent().get(5).getId(), page2_2.getContent().get(0).getId());
-
-    }
+//    @DisplayName("스크랩 목록 조회")
+//    @Test
+//    void getScraps() throws Exception {
+//
+//        //테스트 데이터 생성
+//        ScrapDirectoryEntity directory1 = scrapDirectoryRepository.save(getTestDirectory(user1, "dir1"));
+//        ScrapDirectoryEntity directory2 = scrapDirectoryRepository.save(getTestDirectory(user2, "dir2"));
+//
+//        for (GoogleShopEntity googleShop : googleShops) {
+//            scrapRepository.save(getTestScrap(user1, googleShop, null));
+//            scrapRepository.save(getTestScrap(user1, googleShop, directory1));
+//        }
+//
+//        //디렉토리가 없는 경우
+//        testLogin(user1);
+//        assertThrows(RuntimeException.class, () ->
+//                scrapService.getScraps(null, null, 10)
+//        );
+//
+//        //내가 만든 디렉토리가 아닌 경우
+//        assertThrows(RuntimeException.class, () ->
+//                scrapService.getScraps(directory2.getId(), null, 10)
+//        );
+//
+//        //스크랩 조회
+//        Page<ShopScrapResponse> page1_1 = scrapService.getScraps(0L, null, 10);
+//        Page<ShopScrapResponse> page1_2 = scrapService.getScraps(0L, page1_1.getContent().get(4).getId(), 10);
+//        Page<ShopScrapResponse> page2_1 = scrapService.getScraps(directory1.getId(), null, 10);
+//        Page<ShopScrapResponse> page2_2 = scrapService.getScraps(directory1.getId(), page2_1.getContent().get(4).getId(), 10);
+//
+//        //then
+//        assertEquals(5, page1_2.getContent().size());
+//        assertEquals(5, page2_2.getContent().size());
+//        assertEquals(page1_1.getContent().get(5).getId(), page1_2.getContent().get(0).getId());
+//        assertEquals(page2_1.getContent().get(5).getId(), page2_2.getContent().get(0).getId());
+//
+//    }
 
     @DisplayName("스크랩 이동")
     @Test

--- a/src/test/java/com/jjbacsa/jjbacsabackend/scrap/service/ScrapServiceTest.java
+++ b/src/test/java/com/jjbacsa/jjbacsabackend/scrap/service/ScrapServiceTest.java
@@ -22,10 +22,7 @@ import com.jjbacsa.jjbacsabackend.user.repository.UserRepository;
 import com.jjbacsa.jjbacsabackend.user.service.InternalUserService;
 import com.jjbacsa.jjbacsabackend.util.CursorUtil;
 import lombok.RequiredArgsConstructor;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.Page;
@@ -43,6 +40,7 @@ import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+
 @SpringBootTest
 @RequiredArgsConstructor
 @TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
@@ -57,9 +55,7 @@ class ScrapServiceTest {
     private final GoogleShopRepository googleShopRepository;
     private final ScrapRepository scrapRepository;
     private final ScrapDirectoryRepository scrapDirectoryRepository;
-
     private final EntityManager entityManager;
-
 
     private UserEntity user1;
     private UserEntity user2;
@@ -79,10 +75,10 @@ class ScrapServiceTest {
 
     @BeforeEach
     void setup() {
-
         user1 = userRepository.save(getTestUser("testUser1"));
         user2 = userRepository.save(getTestUser("testUser2"));
-        googleShop1 = googleShopRepository.save(getTestShop("ChIJiavaFuyefDUR5wJus9oVECU"));
+
+        googleShop1 = googleShopRepository.save(getTestShop("ChIJNfWjqxyffDURbVQuwRC4wIs"));
         googleShop2 = googleShopRepository.save(getTestShop("ChIJe9073fyefDUR4FggnKorNT4"));
         googleShop3 = googleShopRepository.save(getTestShop("ChIJj7qqao2efDURv7SvzRmBV0g"));
         googleShop4 = googleShopRepository.save(getTestShop("ChIJ-0U-4_OefDURVh4e90JaaCo"));
@@ -246,43 +242,43 @@ class ScrapServiceTest {
         assertEquals(2, user1.getUserCount().getScrapCount());
     }
 
-//    @DisplayName("스크랩 목록 조회")
-//    @Test
-//    void getScraps() throws Exception {
-//
-//        //테스트 데이터 생성
-//        ScrapDirectoryEntity directory1 = scrapDirectoryRepository.save(getTestDirectory(user1, "dir1"));
-//        ScrapDirectoryEntity directory2 = scrapDirectoryRepository.save(getTestDirectory(user2, "dir2"));
-//
-//        for (GoogleShopEntity googleShop : googleShops) {
-//            scrapRepository.save(getTestScrap(user1, googleShop, null));
-//            scrapRepository.save(getTestScrap(user1, googleShop, directory1));
-//        }
-//
-//        //디렉토리가 없는 경우
-//        testLogin(user1);
-//        assertThrows(RuntimeException.class, () ->
-//                scrapService.getScraps(null, null, 10)
-//        );
-//
-//        //내가 만든 디렉토리가 아닌 경우
-//        assertThrows(RuntimeException.class, () ->
-//                scrapService.getScraps(directory2.getId(), null, 10)
-//        );
-//
-//        //스크랩 조회
-//        Page<ShopScrapResponse> page1_1 = scrapService.getScraps(0L, null, 10);
-//        Page<ShopScrapResponse> page1_2 = scrapService.getScraps(0L, page1_1.getContent().get(4).getId(), 10);
-//        Page<ShopScrapResponse> page2_1 = scrapService.getScraps(directory1.getId(), null, 10);
-//        Page<ShopScrapResponse> page2_2 = scrapService.getScraps(directory1.getId(), page2_1.getContent().get(4).getId(), 10);
-//
-//        //then
-//        assertEquals(5, page1_2.getContent().size());
-//        assertEquals(5, page2_2.getContent().size());
-//        assertEquals(page1_1.getContent().get(5).getId(), page1_2.getContent().get(0).getId());
-//        assertEquals(page2_1.getContent().get(5).getId(), page2_2.getContent().get(0).getId());
-//
-//    }
+    @DisplayName("스크랩 목록 조회")
+    @Test
+    void getScraps() throws Exception {
+
+        //테스트 데이터 생성
+        ScrapDirectoryEntity directory1 = scrapDirectoryRepository.save(getTestDirectory(user1, "dir1"));
+        ScrapDirectoryEntity directory2 = scrapDirectoryRepository.save(getTestDirectory(user2, "dir2"));
+
+        for (GoogleShopEntity googleShop : googleShops) {
+            scrapRepository.save(getTestScrap(user1, googleShop, null));
+            scrapRepository.save(getTestScrap(user1, googleShop, directory1));
+        }
+
+        //디렉토리가 없는 경우
+        testLogin(user1);
+        assertThrows(RuntimeException.class, () ->
+                scrapService.getScraps(null, null, 10)
+        );
+
+        //내가 만든 디렉토리가 아닌 경우
+        assertThrows(RuntimeException.class, () ->
+                scrapService.getScraps(directory2.getId(), null, 10)
+        );
+
+        //스크랩 조회
+        Page<ShopScrapResponse> page1_1 = scrapService.getScraps(0L, null, 10);
+        Page<ShopScrapResponse> page1_2 = scrapService.getScraps(0L, page1_1.getContent().get(4).getScrapId(), 10);
+        Page<ShopScrapResponse> page2_1 = scrapService.getScraps(directory1.getId(), null, 10);
+        Page<ShopScrapResponse> page2_2 = scrapService.getScraps(directory1.getId(), page2_1.getContent().get(4).getScrapId(), 10);
+
+        //then
+        assertEquals(5, page1_2.getContent().size());
+        assertEquals(5, page2_2.getContent().size());
+        assertEquals(page1_1.getContent().get(5).getScrapId(), page1_2.getContent().get(0).getScrapId());
+        assertEquals(page2_1.getContent().get(5).getScrapId(), page2_2.getContent().get(0).getScrapId());
+
+    }
 
     @DisplayName("스크랩 이동")
     @Test


### PR DESCRIPTION
현재 5개로 제한하도록 종속적인 로직으로 구성했지만 추후 yml 파일을 통해 유동적으로 조정할 가능성 있음. 