### PR TITLE
Qclass 인식 문제로 querydsl clean 하는 명령 추가 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -93,6 +93,10 @@ dependencies {
 
 def querydslDir = "$buildDir/generated/querydsl"
 
+clean{
+	delete file(querydslDir)
+}
+
 querydsl {
 	jpa = true
 	querydslSourcesDir = querydslDir
@@ -100,6 +104,7 @@ querydsl {
 sourceSets {
 	main.java.srcDir querydslDir
 }
+
 compileQuerydsl{
 	options.annotationProcessorPath = configurations.querydsl
 }


### PR DESCRIPTION
- 현재 빌드 과정에서 QClass가 생성되지 않는 문제 발생하여 빌드 시에 querydsl clean 하도록 변경하여 Qclass 생성에 문제가 없도록 함.