### PR TITLE
유저 탈퇴 시 문의글 삭제 로직 추가

### DIFF
--- a/src/main/java/com/jjbacsa/jjbacsabackend/inquiry/repository/InquiryRepository.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/inquiry/repository/InquiryRepository.java
@@ -2,9 +2,14 @@ package com.jjbacsa.jjbacsabackend.inquiry.repository;
 
 import com.jjbacsa.jjbacsabackend.inquiry.entity.InquiryEntity;
 import com.jjbacsa.jjbacsabackend.inquiry.repository.querydsl.DslInquiryRepository;
+import com.jjbacsa.jjbacsabackend.user.entity.UserEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface InquiryRepository extends JpaRepository<InquiryEntity, Long>, DslInquiryRepository {
+
+    List<InquiryEntity> findAllByWriter(UserEntity user);
 }

--- a/src/main/java/com/jjbacsa/jjbacsabackend/inquiry/service/InternalInquiryService.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/inquiry/service/InternalInquiryService.java
@@ -1,0 +1,9 @@
+package com.jjbacsa.jjbacsabackend.inquiry.service;
+
+import com.jjbacsa.jjbacsabackend.user.entity.UserEntity;
+
+public interface InternalInquiryService {
+
+    void deleteInquiriesWithUser(UserEntity user) throws Exception;
+
+}

--- a/src/main/java/com/jjbacsa/jjbacsabackend/inquiry/serviceImpl/InternalInquiryServiceImpl.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/inquiry/serviceImpl/InternalInquiryServiceImpl.java
@@ -1,0 +1,40 @@
+package com.jjbacsa.jjbacsabackend.inquiry.serviceImpl;
+
+import com.jjbacsa.jjbacsabackend.inquiry.entity.InquiryEntity;
+import com.jjbacsa.jjbacsabackend.inquiry.repository.InquiryRepository;
+import com.jjbacsa.jjbacsabackend.inquiry.service.InternalInquiryService;
+import com.jjbacsa.jjbacsabackend.inquiry_image.entity.InquiryImageEntity;
+import com.jjbacsa.jjbacsabackend.inquiry_image.service.InternalInquiryImageService;
+import com.jjbacsa.jjbacsabackend.user.entity.UserEntity;
+import com.jjbacsa.jjbacsabackend.user.service.InternalUserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+@Transactional
+@Slf4j
+public class InternalInquiryServiceImpl implements InternalInquiryService {
+
+    private final InquiryRepository inquiryRepository;
+    private final InternalInquiryImageService inquiryImageService;
+    private final InternalUserService userService;
+
+    @Override
+    public void deleteInquiriesWithUser(UserEntity user) throws Exception {
+        UserEntity userEntity = userService.getLoginUser();
+        List<InquiryEntity> inquiries = inquiryRepository.findAllByWriter(userEntity);
+
+        for (InquiryEntity inquiry : inquiries) {
+
+            for (InquiryImageEntity inquiryImage : inquiry.getInquiryImages()) {
+                inquiryImageService.delete(inquiryImage);
+            }
+            inquiryRepository.delete(inquiry);
+        }
+    }
+}

--- a/src/main/java/com/jjbacsa/jjbacsabackend/inquiry_image/serviceImpl/InternalInquiryImageServiceImpl.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/inquiry_image/serviceImpl/InternalInquiryImageServiceImpl.java
@@ -71,7 +71,7 @@ public class InternalInquiryImageServiceImpl implements InternalInquiryImageServ
     @Override
     public void delete(InquiryImageEntity inquiryImageEntity) {
         imageService.deleteImage(inquiryImageEntity.getImage().getId());
-        inquiryImageRepository.deleteById(inquiryImageEntity.getId());
+        inquiryImageRepository.delete(inquiryImageEntity);
     }
 
 }

--- a/src/main/java/com/jjbacsa/jjbacsabackend/review/serviceImpl/InternalReviewServiceImpl.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/review/serviceImpl/InternalReviewServiceImpl.java
@@ -49,7 +49,7 @@ public class InternalReviewServiceImpl implements InternalReviewService {
             for (ReviewImageEntity reviewImage : review.getReviewImages()) { // 리뷰 이미지를 버킷에서 삭제
                 reviewImageService.delete(reviewImage);
             }
-            review.setIsDeleted(1);
+            reviewRepository.delete(review);
 
             // 리뷰 수, 별점 처리
             Long shopId = review.getShop().getId();

--- a/src/main/java/com/jjbacsa/jjbacsabackend/review_image/serviceImpl/InternalReviewImageServiceImpl.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/review_image/serviceImpl/InternalReviewImageServiceImpl.java
@@ -74,6 +74,6 @@ public class InternalReviewImageServiceImpl implements InternalReviewImageServic
     @Override
     public void delete(ReviewImageEntity reviewImageEntity) {
         imageService.deleteImage(reviewImageEntity.getImage().getId());
-        reviewImageRepository.deleteById(reviewImageEntity.getId());
+        reviewImageRepository.delete(reviewImageEntity);
     }
 }

--- a/src/main/java/com/jjbacsa/jjbacsabackend/user/serviceImpl/UserServiceImpl.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/user/serviceImpl/UserServiceImpl.java
@@ -9,6 +9,7 @@ import com.jjbacsa.jjbacsabackend.etc.exception.RequestInputException;
 import com.jjbacsa.jjbacsabackend.follow.service.InternalFollowService;
 import com.jjbacsa.jjbacsabackend.google.service.InternalGoogleService;
 import com.jjbacsa.jjbacsabackend.image.entity.ImageEntity;
+import com.jjbacsa.jjbacsabackend.inquiry.service.InternalInquiryService;
 import com.jjbacsa.jjbacsabackend.review.entity.ReviewEntity;
 import com.jjbacsa.jjbacsabackend.review.service.InternalReviewService;
 import com.jjbacsa.jjbacsabackend.review_image.entity.ReviewImageEntity;
@@ -63,6 +64,7 @@ public class UserServiceImpl implements UserService {
     private final InternalProfileService profileService;
     private final InternalEmailService emailService;
     private final InternalReviewService reviewService;
+    private final InternalInquiryService inquiryService;
     private final InternalReviewImageService reviewImageService;
     private final InternalGoogleService shopService;
     private final UserRepository userRepository;
@@ -246,6 +248,9 @@ public class UserServiceImpl implements UserService {
         // 작성한 리뷰 및 리뷰 내 사진, 별점 삭제
         reviewService.deleteReviewsWithUser(user);
         user.getUserCount().setReviewCount(0);
+
+        // 작성한 문의 및 문의 내 사진 삭제
+        inquiryService.deleteInquiriesWithUser(user);
 
         user.setIsDeleted(1);
 


### PR DESCRIPTION
- 유저 탈퇴 시 Inquiry 삭제 로직 추가하였습니다

수정하는 과정에서 CasCade 작동이 제대로 안하는 부분을 발견하여 수정하였습니다
`setIsDeleted`메서드로 soft delete를 하는 부분이 있었는데
이러한 방식으로 delete하는 것은 cascade가 전파되지 않으며
엔티티에 `SQLDelete` 어노테이션을 활용한 delete 쿼리 설정을 해놨기 때문에 JPA의 delete를 사용하도록 수정하였습니다.