### PR TITLE
Feat: 이름 랜덤 설정 기능 추가

### DIFF
--- a/src/main/java/com/jjbacsa/jjbacsabackend/user/serviceImpl/UserServiceImpl.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/user/serviceImpl/UserServiceImpl.java
@@ -35,6 +35,7 @@ import com.jjbacsa.jjbacsabackend.user.service.UserService;
 import com.jjbacsa.jjbacsabackend.util.AuthLinkUtil;
 import com.jjbacsa.jjbacsabackend.util.ImageUtil;
 import com.jjbacsa.jjbacsabackend.util.JwtUtil;
+import com.jjbacsa.jjbacsabackend.util.NameUtil;
 import com.jjbacsa.jjbacsabackend.util.RedisUtil;
 import java.net.URI;
 import java.util.Date;
@@ -83,7 +84,7 @@ public class UserServiceImpl implements UserService {
         validateExistAccount(request.getAccount());
         validateExistEmail(request.getEmail());
 
-        request.setNickname(UUID.randomUUID().toString());
+        request.setNickname(NameUtil.getNewName());
 
         UserEntity user = UserMapper.INSTANCE.toUserEntity(request).toBuilder()
                 .password(passwordEncoder.encode(request.getPassword()))

--- a/src/main/java/com/jjbacsa/jjbacsabackend/util/NameUtil.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/util/NameUtil.java
@@ -1,0 +1,29 @@
+package com.jjbacsa.jjbacsabackend.util;
+
+import java.util.Random;
+
+public class NameUtil {
+
+    private static String[] prefix = {
+            "잘생긴", "멋진", "귀여운", "대담한",
+            "섹시한", "이쁜", "당당한", "침착한",
+            "명랑한", "용감한", "똑똑한"
+    };
+
+    private static String[] suffix= {
+            "토마토", "감자", "고구마", "오이",
+            "바나나", "사과", "양배추", "레몬",
+            "딸기"
+    };
+
+    public static String getNewName() {
+
+        Random random = new Random();
+
+        int prefixIdx = random.nextInt(prefix.length);
+        int suffixIdx = random.nextInt(suffix.length);
+
+        return prefix[prefixIdx] + suffix[suffixIdx] + random.nextInt(999);
+    }
+
+}


### PR DESCRIPTION
## 진행 사항

- 개발 당시 닉네임 중복 금지로 정책이 수정되어 UUID를 별도로 정리하지 않고 그대로 사용함
- 현재 닉네임 중복 가능 정책으로 재수정되어 랜덤 단어와 랜덤 숫자로 신규 닉네임 구성

### 특이 사항

- suffix와 prefix를 DB에 넣는 것이 좋으나 개발 기간을 고려하여 인라인으로 구성