### PR TITLE
SNS 유저 랜덤 닉네임 추가

### DIFF
--- a/src/main/java/com/jjbacsa/jjbacsabackend/user/serviceImpl/OAuth2UserServiceImpl.java
+++ b/src/main/java/com/jjbacsa/jjbacsabackend/user/serviceImpl/OAuth2UserServiceImpl.java
@@ -18,6 +18,7 @@ import com.jjbacsa.jjbacsabackend.user.repository.UserCountRepository;
 import com.jjbacsa.jjbacsabackend.user.service.InternalUserService;
 import com.jjbacsa.jjbacsabackend.user.service.SnsLogin;
 import com.jjbacsa.jjbacsabackend.util.JwtUtil;
+import com.jjbacsa.jjbacsabackend.util.NameUtil;
 import com.jjbacsa.jjbacsabackend.util.RedisUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
@@ -33,7 +34,6 @@ import javax.servlet.http.HttpServletRequest;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -106,7 +106,7 @@ public class OAuth2UserServiceImpl extends DefaultOAuth2UserService {
                 oAuthInfoRepository.findByApiKeyAndOauthType(oAuth2UserInfo.getApiKey(), oAuth2UserInfo.getOAuthType());
 
         UserEntity user = UserEntity.builder()
-                .account("sns-" + UUID.randomUUID())
+                .account(NameUtil.getNewName())
                 .email(oAuth2UserInfo.getEmail())
                 .nickname(oAuth2UserInfo.getName())
                 .userType(UserType.NORMAL)


### PR DESCRIPTION
## 이슈

- 일반 회원가입 시 랜덤 닉네임 지정이 이뤄졌으나 SNS 로그인 시 그대로 UUID 반환

### 내용

- SNS 회원가입 시 랜덤 닉네임 추가